### PR TITLE
Add test-cases for /search category filtration.

### DIFF
--- a/test_cases/search_categories.json
+++ b/test_cases/search_categories.json
@@ -1,0 +1,104 @@
+{
+  "name": "/search with categories",
+  "priorityThresh": 3,
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "sevko",
+      "type": "dev",
+      "in": {
+        "categories": ["transport:taxi"],
+        "input": "newark"
+      },
+      "expected": {
+        "properties": [{
+          "name": "Taxi Newark Airport",
+          "alpha3": "USA",
+          "admin0": "United States",
+          "admin1": "New Jersey",
+          "admin1_abbr": "NJ",
+          "admin2": "Essex County",
+          "local_admin": "Newark",
+          "locality": "Newark",
+          "neighborhood": "Dayton",
+          "category": [
+            "transport",
+            "transport:taxi"
+          ],
+          "text": "Taxi Newark Airport, Newark, NJ"
+        }]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "sevko",
+      "type": "dev",
+      "in": {
+        "categories": ["recreation"],
+        "input": "east river"
+      },
+      "expected": {
+        "properties": [{
+          "name": "East River Park",
+          "alpha3": "USA",
+          "admin0": "United States",
+          "admin1": "New York",
+          "admin1_abbr": "NY",
+          "admin2": "New York County",
+          "local_admin": "Manhattan",
+          "locality": "New York",
+          "neighborhood": "LoHo",
+          "category": [
+            "recreation"
+          ],
+          "address": {},
+          "text": "East River Park, Manhattan, NY"
+        }]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "sevko",
+      "type": "dev",
+      "in": {
+        "categories": ["accommodation"],
+        "input": "new york city"
+      },
+      "expected": {
+        "properties": [{
+          "alpha3": "USA",
+          "admin0": "United States",
+          "admin1": "New York",
+          "admin1_abbr": "NY",
+          "admin2": "New York County",
+          "local_admin": "Manhattan",
+          "locality": "New York",
+          "category": [
+            "accomodation"
+          ]
+        }]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "sevko",
+      "type": "dev",
+      "in": {
+        "categories": ["natural:water"],
+        "input": "portland"
+      },
+      "expected": {
+        "properties": [{
+          "categories": [
+            "natural",
+            "natural:water"
+          ]
+        }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
```
test_cases/search_categories.json
	-The https://github.com/pelias/api/tree/search-suggest-categories
	PR adds the ability to filter search results by a specific
	category.
	-Add some test-cases for it.
```

fix pelias/api#128