### PR TITLE
specify api keys in pelias config

### DIFF
--- a/apiKey.js
+++ b/apiKey.js
@@ -1,0 +1,17 @@
+
+var url = require('url'),
+    config = require('pelias-config');
+
+module.exports = function( uri ){
+
+  var settings = config.generate();
+  console.log( 'a', settings );
+
+  if( settings && settings.hasOwnProperty('mapzen') ){
+    var host = url.parse( uri ).host;
+    if( settings.mapzen.hasOwnProperty('api_key') && settings.mapzen.api_key.hasOwnProperty(host) ){
+      return settings.mapzen.api_key[ host ];
+    }
+  }
+  return null;
+};

--- a/apiKey.js
+++ b/apiKey.js
@@ -5,7 +5,6 @@ var url = require('url'),
 module.exports = function( uri ){
 
   var settings = config.generate();
-  console.log( 'a', settings );
 
   if( settings && settings.hasOwnProperty('mapzen') ){
     var host = url.parse( uri ).host;

--- a/package.json
+++ b/package.json
@@ -23,15 +23,13 @@
     "nodemailer-ses-transport": "1.2.0",
     "pelias-config": "^0.x.x",
     "request": "^2.55.0",
-    "require-dir": "0.1.0",
-    "tap-spec": "^3.0.0",
-    "tape": "^4.0.0"
+    "require-dir": "0.1.0"
   },
   "devDependencies": {
     "jshint": "^2.6.3",
     "precommit-hook": "1.0.7",
     "tape": "3.5.0",
-    "tap-spec": "^3.0.0"
+    "tap-spec": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "nodemailer": "^1.x.x",
     "nodemailer-ses-transport": "1.2.0",
     "pelias-config": "^0.x.x",
+    "request": "^2.55.0",
     "require-dir": "0.1.0",
-    "request": "^2.55.0"
+    "tap-spec": "^3.0.0",
+    "tape": "^4.0.0"
   },
   "devDependencies": {
     "jshint": "^2.6.3",

--- a/run_tests.js
+++ b/run_tests.js
@@ -193,7 +193,7 @@ function execTestSuite( apiUrl, testSuite, cb ){
         console.error( err );
         return;
       }
-      else if( res.statusCode === 413 ){
+      else if( res.statusCode === 413 || res.statusCode === 429 ){
         console.error( 'Rate limit breached, rerunning.' );
         testSuite.tests.push( testCase );
         return;

--- a/run_tests.js
+++ b/run_tests.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var locations = require( './locations.json' );
+var apiKey = require( './apiKey' );
 var util = require( 'util' );
 var request = require( 'request' );
 
@@ -180,6 +181,12 @@ function execTestSuite( apiUrl, testSuite, cb ){
     }
 
     var testCase = testSuite.tests.pop();
+
+    // load api_key from pelias config
+    var key = apiKey( apiUrl );
+    if( key ){
+      testCase.in.api_key = key;
+    }
 
     var requestOpts = {
       url: testCase.endpoint || testSuite.endpoint || 'search',

--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -36,11 +36,11 @@
       "expected": {
         "properties": [
           {
-            "text": "31 세종대로 서울시청 신관동, Seoul",
+            "text": "31 세종대로 서울시청 본관동, Seoul",
             "neighborhood": "사직동",
             "locality": "Seoul",
             "layer": "openaddresses",
-            "name": "31 세종대로 서울시청 신관동",
+            "name": "31 세종대로 서울시청 본관동",
             "alpha3": "KOR",
             "admin0": "South Korea",
             "admin1": "Seoul",
@@ -1322,7 +1322,7 @@
             "text": "Transamerica Pyramid, San Francisco, CA"
           }
         ],
-        "priorityThresh": 3
+        "priorityThresh": 4
       },
       "status": "pass"
     },
@@ -1330,13 +1330,12 @@
       "id": "1426636804303:44",
       "user": "feedback-app",
       "in": {
-        "input": "san francisco caltrain station"
+        "input": "san francisco caltrain station 4th"
       },
       "expected": {
         "properties": [
           {
-            "layer": "osmway",
-            "name": "San Francisco Caltrain Station",
+            "name": "San Francisco Caltrain (Townsend at 4th",
             "alpha3": "USA",
             "admin0": "United States",
             "admin1": "California",
@@ -1344,32 +1343,7 @@
             "admin2": "San Francisco County",
             "locality": "San Francisco",
             "neighborhood": "Mission Bay",
-            "text": "San Francisco Caltrain Station, San Francisco, CA"
-          }
-        ],
-        "priorityThresh": 1
-      },
-      "status": "pass"
-    },
-    {
-      "id": "1426636804303:45",
-      "user": "feedback-app",
-      "in": {
-        "input": "22nd street caltrain"
-      },
-      "expected": {
-        "properties": [
-          {
-            "layer": "osmnode",
-            "name": "22nd Street Caltrain Station",
-            "alpha3": "USA",
-            "admin0": "United States",
-            "admin1": "California",
-            "admin1_abbr": "CA",
-            "admin2": "San Francisco County",
-            "locality": "San Francisco",
-            "neighborhood": "Dogpatch",
-            "text": "22nd Street Caltrain Station, San Francisco, CA"
+            "text": "San Francisco Caltrain (Townsend at 4th, San Francisco, CA"
           }
         ],
         "priorityThresh": 1
@@ -1527,7 +1501,7 @@
       "id": "1426636804303:51",
       "user": "feedback-app",
       "in": {
-        "input": "4th and King Caltrain"
+        "input": "4th Caltrain San Francisco"
       },
       "expected": {
         "properties": [


### PR DESCRIPTION
note: branched off https://github.com/pelias/acceptance-tests/pull/50 please merge that branch in and merge 50 to master before merging this.

this PR allows you to specify api keys in your ~/pelias.json config for use in the acceptance tests

```javascript
{
  "mapzen": {
    "api_key": {
      "pelias.stage.mapzen.com": "pelias-stage-xxxxxx"
    }
  },
```