### PR TITLE
[discuss] test case changes

### DIFF
--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -12,7 +12,9 @@
       },
       "expected": {
         "properties": [
-          "Brooklyn , Kings County, New York"
+          {
+            "text": "Brooklyn, NY"
+          }
         ]
       }
     },
@@ -26,7 +28,9 @@
       },
       "expected": {
         "properties": [
-          "Brooklyn , Kings County, New York"
+          {
+            "text": "Brooklyn, NY"
+          }
         ]
       }
     },
@@ -40,7 +44,9 @@
       },
       "expected": {
         "properties": [
-          "New York, New York"
+          {
+            "text": "New York, NY"
+          }
         ]
       }
     },
@@ -77,7 +83,9 @@
       },
       "expected": {
         "properties": [
-          "New York, New York"
+          {
+            "text": "New York City, Manhattan, NY"
+          }
         ]
       }
     },
@@ -112,7 +120,9 @@
       "expected": {
         "priorityThresh": 1,
         "properties": [
-          "Billerica, Middlesex County, Massachusetts"
+          {
+            "text": "Billerica, MA"
+          }
         ]
       }
     },
@@ -127,7 +137,9 @@
       "expected": {
         "priorityThresh": 1,
         "properties": [
-          "Billerica, Middlesex County, Massachusetts"
+          {
+            "text": "Billerica, MA"
+          }
         ]
       }
     },
@@ -357,7 +369,7 @@
             "admin2": "New York County",
             "local_admin": "Manhattan",
             "locality": "New York",
-            "text": "SoHo, Manhattan, NY"
+            "text": "Soho, New York County, NY"
           }
         ]
       }
@@ -374,12 +386,11 @@
         "priorityThresh": 3,
         "properties": [
           {
-            "name": "1 Main St.",
+            "name": "1 Main St",
             "alpha3": "GBR",
             "admin0": "United Kingdom",
             "admin1": "Dungannon",
-            "admin2": "County Monaghan",
-            "text": "1 Main St., County Monaghan"
+            "text": "1 Main St, United Kingdom"
           }
         ]
       }


### PR DESCRIPTION
some of the test cases are producing false positives due to using text matching on the output `text` property rather than exact matching on the properties.

a good example is the input `'new york'` for the output `'New York, New York'`; in production the test `passed` because it matched:

```bash
"text": "New York New York, Sutton, Greater London"
"text": "New York New York, Tampa, FL"
"text": "New York New York, Chinatown, Greater Manchester"
"text": "New York! New York!, Palo Alto, CA"
"text": "New York New York, Aqaba"
"text": "New York New York, Oldenburg (Oldenburg), Niedersachsen"
"text": "New York, NY"
"text": "New York, NY"
"text": "New York, Kings County, NY"
"text": "New York, Wildmore CP, United Kingdom"
```

whereas it `failed` on staging for:

```bash
"text": "New York, NY"
"text": "New York, NY"
"text": "New York, Kings County, NY"
"text": "New York, Tolima"
"text": "New York, Wildmore CP, United Kingdom"
"text": "New York, Casanare"
"text": "New York, Wildmore CP, United Kingdom"
"text": "New York, Wildmore CP, United Kingdom"
"text": "New York, Wildmore CP, United Kingdom"
"text": "New York, York County, NE"
```

this makes me worry that we might be testing the wrong things, or having too much faith in what the system *currently* produces rather than what it *should* produce. 

additionally I had to change some entries like `"Billerica, Middlesex County, Massachusetts" -> "Billerica, MA"` and `"SoHo, Manhattan, NY" -> "Soho, New York County, NY"` which seems wrong, was there a change made to the API for generating output strings?
 
