### PR TITLE
Fix admin_lookup test IDs

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -208,7 +208,7 @@
       }
     },
     {
-      "id": "10",
+      "id": "11",
       "status": "pass",
       "endpoint": "reverse",
       "in": {
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "11",
+      "id": "12",
       "status": "pass",
       "endpoint": "reverse",
       "in": {
@@ -246,7 +246,7 @@
       }
     },
     {
-      "id": "12",
+      "id": "13",
       "status": "pass",
       "type": "dev",
       "in": {
@@ -269,7 +269,7 @@
       }
     },
     {
-      "id": "13",
+      "id": "14",
       "status": "pass",
       "type": "dev",
       "in": {
@@ -292,7 +292,7 @@
       }
     },
     {
-      "id": "14",
+      "id": "15",
       "status": "pass",
       "type": "dev",
       "in": {
@@ -315,7 +315,7 @@
       }
     },
     {
-      "id": "15",
+      "id": "16",
       "status": "pass",
       "type": "dev",
       "in": {
@@ -336,7 +336,7 @@
       }
     },
     {
-      "id": "16",
+      "id": "17",
       "status": "pass",
       "type": "dev",
       "in": {


### PR DESCRIPTION
There were some duplicate test IDs that were easy to fix. Doesn't look
like it affects anything other than making the test output not as well
ordered.