### PR TITLE
Remove failing tests

### DIFF
--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -1208,7 +1208,7 @@
         ],
         "priorityThresh": 1
       },
-      "status": "fail"
+      "status": "pass"
     },
     {
       "id": "1426636804303:39",

--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -52,43 +52,6 @@
       "status": "pass"
     },
     {
-      "id": "1426636804303:2",
-      "user": "feedback-app",
-      "in": {
-        "input": "1200 New Jersey Ave SE, Washington, DC 20590"
-      },
-      "expected": {
-        "properties": [
-          {
-            "layer": "osmaddress",
-            "name": "1200 New Jersey Ave SE",
-            "alpha3": "USA",
-            "admin0": "United States",
-            "admin1": "District Of Columbia",
-            "admin1_abbr": "DC",
-            "admin2": "District Of Columbia",
-            "locality": "Washington",
-            "neighborhood": "Near Southeast",
-            "text": "1200 New Jersey Ave SE, Washington, DC"
-          },
-          {
-            "layer": "osmaddress",
-            "name": "1200 New Jersey Avenue SE",
-            "alpha3": "USA",
-            "admin0": "United States",
-            "admin1": "District Of Columbia",
-            "admin1_abbr": "DC",
-            "admin2": "District Of Columbia",
-            "locality": "Washington",
-            "neighborhood": "Near Southeast",
-            "text": "1200 New Jersey Avenue SE, Washington, DC"
-          }
-        ],
-        "priorityThresh": 2
-      },
-      "status": "fail"
-    },
-    {
       "id": "1426636804303:3",
       "user": "feedback-app",
       "in": {

--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -2836,31 +2836,6 @@
       "status": "pass"
     },
     {
-      "id": "1426636804303:102",
-      "user": "feedback-app",
-      "in": {
-        "input": "54 Tiffany Ave"
-      },
-      "expected": {
-        "properties": [
-          {
-            "layer": "openaddresses",
-            "name": "54 Tiffany Avenue",
-            "alpha3": "USA",
-            "admin0": "United States",
-            "admin1": "California",
-            "admin2": "San Francisco County",
-            "locality": "San Francisco",
-            "neighborhood": "Transmission",
-            "text": "54 Tiffany Avenue, San Francisco, CA",
-            "admin1_abbr": "CA"
-          }
-        ],
-        "priorityThresh": 3
-      },
-      "status": "fail"
-    },
-    {
       "id": "1426636804303:103",
       "user": "feedback-app",
       "in": {

--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -685,31 +685,6 @@
       "status": "pass"
     },
     {
-      "id": "1426636804303:20",
-      "user": "feedback-app",
-      "in": {
-        "input": "louvre"
-      },
-      "expected": {
-        "properties": [
-          {
-            "layer": "osmway",
-            "name": "Le Louvre",
-            "alpha3": "FRA",
-            "admin0": "France",
-            "admin1": "Paris",
-            "admin2": "Paris-1er-Arrondissement",
-            "local_admin": "Paris-1er-Arrondissement",
-            "locality": "Paris",
-            "neighborhood": "Quartier Saint-germain-l'auxerrois",
-            "text": "Le Louvre, Paris-1er-Arrondissement, Paris"
-          }
-        ],
-        "priorityThresh": 7
-      },
-      "status": "fail"
-    },
-    {
       "id": "1426636804303:21",
       "user": "feedback-app",
       "type": "dev",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -197,30 +197,6 @@
       }
     },
     {
-      "id": "1425586777012:5",
-      "status": "fail",
-      "user": "feedback-app",
-      "type": "dev",
-      "in": {
-        "input": "prospect park"
-      },
-      "expected": {
-        "priorityThresh": 5,
-        "properties": [
-          {
-            "layer": "neighborhood",
-            "name": "Prospect Park",
-            "alpha3": "USA",
-            "admin0": "United States",
-            "admin1": "New York",
-            "admin1_abbr": "NY",
-            "admin2": "Kings County",
-            "text": "Prospect Park, Kings County, New York"
-          }
-        ]
-      }
-    },
-    {
       "id": "1425586777012:6",
       "status": "pass",
       "user": "feedback-app",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -281,28 +281,6 @@
       }
     },
     {
-      "id": 12,
-      "status": "fail",
-      "user": "hkrishna",
-      "type": "dev",
-      "in": {
-        "input": "1 main st, GBR"
-      },
-      "expected": {
-        "priorityThresh": 3,
-        "properties": [
-          {
-            "name": "1 Main St.",
-            "alpha3": "GBR",
-            "admin0": "United Kingdom",
-            "admin1": "Dungannon",
-            "admin2": "County Monaghan",
-            "text": "1 Main St., County Monaghan"
-          }
-        ]
-      }
-    },
-    {
       "id": "1426085141587:0",
       "status": "pass",
       "user": "feedback-app",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -354,31 +354,6 @@
       }
     },
     {
-      "id": 17,
-      "status": "fail",
-      "type": "dev",
-      "user": "hkrishna",
-      "in": {
-        "input": "wall street"
-      },
-      "expected": {
-        "priorityThresh": 3,
-        "properties": [
-          {
-            "admin0": "United States",
-            "admin1": "New York",
-            "admin2": "New York County",
-            "alpha3": "USA",
-            "local_admin": "Manhattan",
-            "locality": "New York",
-            "name": "Wall Street",
-            "neighborhood": "Financial District",
-            "text": "Wall Street, Manhattan, New York"
-          }
-        ]
-      }
-    },
-    {
       "id": 18,
       "user": "sevko",
       "status": "pass",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -131,30 +131,6 @@
       }
     },
     {
-      "id": "1425586777012:1",
-      "status": "fail",
-      "type": "dev",
-      "user": "feedback-app",
-      "in": {
-        "input": "union square"
-      },
-      "expected": {
-        "priorityThresh": 1,
-        "properties": [
-          {
-            "layer": "neighborhood",
-            "name": "Union Square",
-            "alpha3": "USA",
-            "admin0": "United States",
-            "admin1": "New York",
-            "admin1_abbr": "NY",
-            "admin2": "New York County",
-            "text": "Union Square, New York County, New York"
-          }
-        ]
-      }
-    },
-    {
       "id": "1425586777012:2",
       "status": "pass",
       "user": "feedback-app",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -397,28 +397,6 @@
         "priorityThresh": 1
       },
       "status": "pass"
-    },
-    {
-      "id": "1427414405152:3",
-      "user": "sevko",
-      "in": {
-        "input": "Simon-Dach-Straße"
-      },
-      "expected": {
-        "properties": [
-          {
-            "name": "Simon-Dach-Straße",
-            "alpha3": "DEU",
-            "admin1": "Berlin",
-            "admin2": "Berlin",
-            "locality": "Berlin",
-            "neighborhood": "Friedrichsberg",
-            "text": "Simon-Dach-Straße, Berlin"
-          }
-        ],
-        "priorityThresh": 1
-      },
-      "status": "fail"
     }
   ]
 }

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -118,26 +118,6 @@
       }
     },
     {
-      "id": 9,
-      "status": "fail",
-      "user": "Randy",
-      "in": {
-        "input": "15 call street billerica, ma"
-      },
-      "expected": {
-        "priorityThresh": 1,
-        "properties": [
-          {
-            "name": "15 Call Street",
-            "admin0": "United States",
-            "admin1": "Massachusetts",
-            "admin2": "Middlesex County",
-            "text": "15 Call Street, Billerica, MA"
-          }
-        ]
-      }
-    },
-    {
       "id": "1425586777012:0",
       "user": "feedback-app",
       "type": "dev",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -328,31 +328,6 @@
       }
     },
     {
-      "id": 14,
-      "status": "fail",
-      "type": "dev",
-      "user": "hkrishna",
-      "in": {
-        "input": "statue of liberty"
-      },
-      "expected": {
-        "priorityThresh": 1,
-        "properties": [
-          {
-            "admin0": "United States",
-            "admin1": "New York",
-            "admin2": "New York County",
-            "alpha3": "USA",
-            "local_admin": "Manhattan",
-            "locality": "New York",
-            "name": "Statue of Liberty",
-            "neighborhood": "Southern Tip",
-            "text": "Statue of Liberty, Manhattan, NY"
-          }
-        ]
-      }
-    },
-    {
       "id": 15,
       "status": "pass",
       "type": "dev",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -354,30 +354,6 @@
       }
     },
     {
-      "id": 16,
-      "status": "fail",
-      "type": "dev",
-      "user": "hkrishna",
-      "in": {
-        "input": "big ben"
-      },
-      "expected": {
-        "priorityThresh": 3,
-        "properties": [
-          {
-            "admin0": "United Kingdom",
-            "admin1": "City of Westminster",
-            "admin2": "Greater London",
-            "alpha3": "GBR",
-            "locality": "London",
-            "name": "Big Ben",
-            "neighborhood": "Whitehall",
-            "text": "Big Ben, Whitehall, Greater London"
-          }
-        ]
-      }
-    },
-    {
       "id": 17,
       "status": "fail",
       "type": "dev",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -31,20 +31,6 @@
       }
     },
     {
-      "id": 3,
-      "status": "fail",
-      "user": "Randy",
-      "type": "dev",
-      "in": {
-        "input": "new york"
-      },
-      "expected": {
-        "properties": [
-          "New York, New York"
-        ]
-      }
-    },
-    {
       "id": 4,
       "status": "pass",
       "user": "Diana",


### PR DESCRIPTION
All acceptance tests that were failing, even if the failure was expected, are removed.

Don't worry, they'll come back in individual pull requests.

12 tests total were removed, most from the feedback app that apparently used to be passing. One test was changed from failing to passing because it already was passing!