### PR TITLE
Add 22nd st caltrain test

### DIFF
--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -1327,6 +1327,31 @@
       "status": "pass"
     },
     {
+      "id": "1426636804303:45",
+      "user": "feedback-app",
+      "in": {
+        "input": "22nd street caltrain"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "osmnode",
+            "name": "22nd Street Caltrain Station",
+            "alpha3": "USA",
+            "admin0": "United States",
+            "admin1": "California",
+            "admin1_abbr": "CA",
+            "admin2": "San Francisco County",
+            "locality": "San Francisco",
+            "neighborhood": "Dogpatch",
+            "text": "22nd Street Caltrain Station, San Francisco, CA"
+          }
+        ],
+        "priorityThresh": 1
+      },
+      "status": "pass"
+    },
+    {
       "id": "1426636804303:46",
       "user": "feedback-app",
       "in": {


### PR DESCRIPTION
This reverts commit fb457da19baf8f60a27f5bff9f8b353c176d3e73.

Right now, even though the 22nd St Caltrain station is in OSM, it
doesn't show up in search results for "22nd st caltrain".

OSM node: http://www.openstreetmap.org/node/2160213364