### PR TITLE
Add 4th and king caltrain test

### DIFF
--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -472,6 +472,23 @@
           "country_a": "USA"
         }]
       }
+    },
+    {
+      "id": "1426636804303:51",
+      "user": "feedback-app",
+      "in": {
+        "text": "4th and King"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "San Francisco 4th & King Street Station",
+            "country_a": "USA"
+          }
+        ],
+        "priorityThresh": 2
+      },
+      "status": "pass"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 969df26205dfac5b36f95e393daab4a44bd64ef9.

The test fails because the 4th and king station shows far too down in
the search results.