### PR TITLE
fix test

### DIFF
--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -30,6 +30,7 @@
       "id": "1426636804303:1",
       "user": "feedback-app",
       "status": "fail",
+      "issue": "https://github.com/pelias/acceptance-tests/pull/96",
       "in": {
         "input": "서울시청"
       },

--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -40,8 +40,7 @@
             "text": "서울특별시청 (Seoul City Hall), Seoul"
           }
         ]
-      },
-      "status": "pass"
+      }
     },
     {
       "id": "1426636804303:3",

--- a/test_cases/feedback_pass.json
+++ b/test_cases/feedback_pass.json
@@ -29,21 +29,14 @@
     {
       "id": "1426636804303:1",
       "user": "feedback-app",
+      "status": "fail",
       "in": {
         "input": "서울시청"
       },
       "expected": {
         "properties": [
           {
-            "text": "31 세종대로 서울시청 본관동, Seoul",
-            "neighborhood": "사직동",
-            "locality": "Seoul",
-            "layer": "openaddresses",
-            "name": "31 세종대로 서울시청 본관동",
-            "alpha3": "KOR",
-            "admin0": "South Korea",
-            "admin1": "Seoul",
-            "admin2": "종로구"
+            "text": "서울특별시청 (Seoul City Hall), Seoul"
           }
         ]
       },


### PR DESCRIPTION
disclaimer: I don't speak korean

I'm pretty sure this test case is wrong, I used an online translation tool I get:
`서울시청`->`City Hall` and nominatum corroborates that with: http://www.openstreetmap.org/way/198561926

The expected result `31 세종대로 서울시청 본관동` is a street address which translates to `31, Sejong University in Seoul City Hall main building` which is almost correct and the lat/lons match.

I think this is the result we *should* be returning is: http://pelias.mapzen.com/doc?id=osmway:198561926 although it's not properly searchable as we currently don't index the `alt_name:ko` tag, see: https://github.com/pelias/openstreetmap/blob/master/config/localized_name_keys.js

...so it's marked as `status:fail` for now