### PR TITLE
fail fast if apiResults doesnt exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "nodemailer-ses-transport": "1.2.0",
     "pelias-config": "^0.x.x",
     "require-dir": "0.1.0",
-    "request": "^2.55.0"
+    "request": "^2.55.0",
+    "is-object": "^1.0.1"
   },
   "devDependencies": {
     "jshint": "^2.6.3",

--- a/run_tests.js
+++ b/run_tests.js
@@ -43,7 +43,7 @@ function evalTest( priorityThresh, testCase, apiResults ){
     };
   }
 
-  if ( apiResults.length === 0 ) {
+  if ( !apiResults || apiResults.length === 0 ) {
     return {
       result: 'fail',
       msg: 'no results returned'

--- a/run_tests.js
+++ b/run_tests.js
@@ -6,6 +6,7 @@
 
 var locations = require( './locations.json' );
 var util = require( 'util' );
+var isObject = require( 'is-object' );
 var request = require( 'request' );
 
 /**
@@ -43,7 +44,7 @@ function evalTest( priorityThresh, testCase, apiResults ){
     };
   }
 
-  if ( !apiResults || apiResults.length === 0 ) {
+  if ( !isObject(apiResults) || apiResults.length === 0 ) {
     return {
       result: 'fail',
       msg: 'no results returned'


### PR DESCRIPTION
This PR marks a test case as a failure if the API response does not have a results object and avoid the following error

```
TypeError: Cannot read property 'length' of undefined
    at evalTest (/Users/harishkrishna/code/pelias/acceptance-tests/run_tests.js:46:18)
    at Request._callback (/Users/harishkrishna/code/pelias/acceptance-tests/run_tests.js:220:21)
    at Request.self.callback (/Users/harishkrishna/code/pelias/acceptance-tests/node_modules/request/request.js:368:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/Users/harishkrishna/code/pelias/acceptance-tests/node_modules/request/request.js:1219:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/Users/harishkrishna/code/pelias/acceptance-tests/node_modules/request/request.js:1167:12)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
```