### PR TITLE
Retry tests on 500 errors

### DIFF
--- a/run_tests.js
+++ b/run_tests.js
@@ -194,7 +194,7 @@ function execTestSuite( apiUrl, testSuite, cb ){
         console.error( err );
         return;
       }
-      else if( res.statusCode === 413 || res.statusCode === 429 ){
+      else if( res.statusCode === 413 || res.statusCode === 429 || res.statusCode === 500 ){
         testSuite.tests.push( testCase );
         return;
       }


### PR DESCRIPTION
This is hopefully a temporary measure that retries tests when there is a
500 error. Ideally we would be able to distinguish between unrecoverable
errors and timeouts by return code, and only retry timeouts. If someday
there are cases that will consistently 500, this change will cause the
tests to loop forever.