### PR TITLE
Use exponential backoff when running tests

### DIFF
--- a/lib/ExponentialBackoff.js
+++ b/lib/ExponentialBackoff.js
@@ -1,5 +1,13 @@
 'use strict';
 
+/**
+ * ExponentialBackoff class handles the logic for increasing or decreasing the delay between
+ * multiple requests. See https://en.wikipedia.org/wiki/Exponential_backoff
+ *
+ * @param {number} minimum_backoff the lowest permissible delay between requests. defaults to 50ms
+ * @param {number} exponent the factor by which to increse or decrease the backoff. defaults to 2
+ * @param {number} starting_backoff the backoff between the first and second request. defaults to * 50ms
+ */
 var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
     this.minimum_backoff = minimum_backoff || 50;
     this.exponent = exponent || 2.0;
@@ -8,14 +16,26 @@ var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
     this.backoff = starting_backoff;
 };
 
+/**
+ * Get the current backoff as a simple number
+ */
 ExponentialBackoff.prototype.getBackoff = function getBackoff() {
     return this.backoff;
 };
 
+
+/**
+ * Increase the backoff for the next request. This method should be called after something happens
+ * that would indicate a slowdown is needed, such as a failed request.
+ */
 ExponentialBackoff.prototype.increaseBackoff = function increaseBackoff() {
     this.backoff *= this.exponent;
 };
 
+/**
+ * Decrease the backoff for the next request. The backoff will never go below the miniumum backoff
+ * value. This should be called when things are going smoothly, such as after a successful request.
+ */
 ExponentialBackoff.prototype.decreaseBackoff = function decreaseBackoff() {
     if (this.backoff <= this.minimum_backoff) {
         this.backoff = this.minimum_backoff;

--- a/lib/ExponentialBackoff.js
+++ b/lib/ExponentialBackoff.js
@@ -1,27 +1,27 @@
 'use strict';
 
 var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
-    minimum_backoff = minimum_backoff || 50;
-    exponent = exponent || 2.0;
-    starting_backoff = starting_backoff || minimum_backoff;
+    this.minimum_backoff = minimum_backoff || 50;
+    this.exponent = exponent || 2.0;
+    this.starting_backoff = starting_backoff || minimum_backoff;
 
-    var backoff = starting_backoff;
+    this.backoff = starting_backoff;
+};
 
-    return {
-        getBackoff: function() {
-            return backoff;
-        },
-        increaseBackoff: function() {
-            backoff *= exponent;
-        },
-        decreaseBackoff: function() {
-            if (backoff <= minimum_backoff) {
-                backoff = minimum_backoff;
-            } else {
-                backoff /= exponent;
-            }
-        }
-    };
+ExponentialBackoff.prototype.getBackoff = function getBackoff() {
+    return this.backoff;
+};
+
+ExponentialBackoff.prototype.increaseBackoff = function increaseBackoff() {
+    this.backoff *= this.exponent;
+};
+
+ExponentialBackoff.prototype.decreaseBackoff = function decreaseBackoff() {
+    if (this.backoff <= this.minimum_backoff) {
+        this.backoff = this.minimum_backoff;
+    } else {
+        this.backoff /= this.exponent;
+    }
 };
 
 module.exports = ExponentialBackoff;

--- a/lib/ExponentialBackoff.js
+++ b/lib/ExponentialBackoff.js
@@ -1,17 +1,9 @@
 'use strict';
 
 var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
-    if (minimum_backoff === undefined) {
-        minimum_backoff = 50;
-    }
-
-    if (exponent === undefined) {
-        exponent = 2.0;
-    }
-
-    if (starting_backoff === undefined) {
-        starting_backoff = minimum_backoff;
-    }
+    minimum_backoff = minimum_backoff || 50;
+    exponent = exponent || 2.0;
+    starting_backoff = starting_backoff || minimum_backoff;
 
     var backoff = starting_backoff;
 

--- a/lib/ExponentialBackoff.js
+++ b/lib/ExponentialBackoff.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
+    if (minimum_backoff === undefined) {
+        minimum_backoff = 50;
+    }
+
+    if (exponent === undefined) {
+        exponent = 2.0;
+    }
+
+    if (starting_backoff === undefined) {
+        starting_backoff = minimum_backoff;
+    }
+
+    var backoff = starting_backoff;
+
+    return {
+        getBackoff: function() {
+            return backoff;
+        },
+        increaseBackoff: function() {
+            backoff *= exponent;
+        },
+        decreaseBackoff: function() {
+            if (backoff <= minimum_backoff) {
+                backoff = minimum_backoff;
+            } else {
+                backoff /= exponent;
+            }
+        }
+    };
+};
+
+module.exports = ExponentialBackoff;

--- a/lib/ExponentialBackoff.js
+++ b/lib/ExponentialBackoff.js
@@ -11,9 +11,9 @@
 var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
     this.minimum_backoff = minimum_backoff || 50;
     this.exponent = exponent || 2.0;
-    this.starting_backoff = starting_backoff || minimum_backoff;
+    this.starting_backoff = starting_backoff || this.minimum_backoff;
 
-    this.backoff = starting_backoff;
+    this.backoff = this.starting_backoff;
 };
 
 /**


### PR DESCRIPTION
In order to keep our tests from completely killing our production or
staging servers, this change uses a simple [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff)
algorithm to increase the delay between requests when we get error codes
like 408 that indicate our server is overloaded.