### PR TITLE
Move json failure files to output_generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 .validate.json
 errors-*.json
+fail_*.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 .idea
 .validate.json
 errors-*.json
-fail_*.json
+failures

--- a/output_generators/json.js
+++ b/output_generators/json.js
@@ -1,0 +1,42 @@
+/**
+ * @file A terminal/json-file output generator for test-suites results.
+ */
+
+'use strict';
+
+var util = require( 'util' );
+var fs = require('fs-extra');
+var terminal = require('./terminal');
+var sanitize_filename = require('sanitize-filename');
+
+/**
+ * Format and print a test result to json file.
+ */
+function saveFailTestResult( result ) {
+  if( result.result === 'fail' && result.testCase.status === 'pass' ) {
+    fs.ensureDirSync('./failures');
+    var recordFailFile = './failures/' + sanitize_filename(
+        util.format('%s_%s.json', result.testCase.id, result.testCase.in.input));
+    var recordFail = {
+      test_case: result.testCase,
+      response: result.response.body.features
+    };
+    fs.writeFileSync(recordFailFile, JSON.stringify(recordFail, null, 2));
+  }
+}
+
+/**
+ * Format and print all of the results from any number of test-suites.
+ */
+function prettyPrintSuiteResults( suiteResults ) {
+
+  suiteResults.results.forEach( function ( suiteResult ) {
+    suiteResult.results.forEach( function (testResult) {
+      saveFailTestResult( testResult );
+    });
+  });
+
+  terminal( suiteResults );
+}
+
+module.exports = prettyPrintSuiteResults;

--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
   "dependencies": {
     "colors": "^1.x.x",
     "commander": "2.7.0",
+    "fs-extra": "^0.22.1",
     "handlebars": "^3.x.x",
+    "is-object": "^1.0.1",
     "juice": "^1.x.x",
     "nodemailer": "^1.x.x",
     "nodemailer-ses-transport": "1.2.0",
     "pelias-config": "^0.x.x",
-    "require-dir": "0.1.0",
     "request": "^2.55.0",
-    "is-object": "^1.0.1"
+    "require-dir": "0.1.0",
+    "sanitize-filename": "^1.3.0"
   },
   "devDependencies": {
     "jshint": "^2.6.3",

--- a/run_tests.js
+++ b/run_tests.js
@@ -224,10 +224,6 @@ function execTestSuite( apiUrl, testSuite, cb ){
         results.progress = 'improvement';
       }
       else if( results.result === 'fail' && testCase.status === 'pass' ){
-        // uncomment for debugging
-        // require('fs').writeFileSync('fail_' + testCase.id + '.json', JSON.stringify(res.body.features));
-        // end of debugging code
-
         // subtract the regression from fail count, so we don't double count them
         testResults.stats.fail--;
         testResults.stats.regression++;
@@ -235,6 +231,7 @@ function execTestSuite( apiUrl, testSuite, cb ){
       }
 
       results.testCase = testCase;
+      results.response = res;
       testResults.stats[ results.result ]++;
       testResults.results.push( results );
 


### PR DESCRIPTION
Using this new output_generator you can generate json file per failing test. Files will be placed in `./failures`

usage:  `$ node test -o json`