### PR TITLE
Search query builder not checking all available admin values

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -35,7 +35,8 @@
     },
     {
       "id": 2,
-      "status": "pass",
+      "status": "fail",
+      "issue": "https://github.com/pelias/api/issues/187",
       "user": "Harish",
       "type": "dev",
       "in": {


### PR DESCRIPTION
Mark failing test as a known bug. The test was relying on the order in which the data
was being imported. Coincidently it exposed a bug in the search query building logic
with regard to admin field matching.

See [issue](https://github.com/pelias/api/issues/187) for more details