### PR TITLE
Add admin3 filter tests

### DIFF
--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -537,6 +537,46 @@
           }
         ]
       }
+    },
+    {
+      "id": 20,
+      "user": "orangejulius",
+      "in": {
+        "text": "statue of liberty",
+        "boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [{
+          "name": "Statue of Liberty",
+          "country_a": "USA",
+          "country": "New York"
+        }]
+      },
+      "unexpected": {
+        "properties": [{
+          "country_a": "FRA"
+        }]
+      }
+    },
+    {
+      "id": 20,
+      "user": "orangejulius",
+      "in": {
+        "text": "statue of liberty",
+        "boundary.country": "FRA"
+      },
+      "expected": {
+        "properties": [{
+          "name": "Statue of Liberty",
+          "country_a": "FRA",
+          "country": "Paris"
+        }]
+      },
+      "unexpected": {
+        "properties": [{
+          "country_a": "USA"
+        }]
+      }
     }
   ]
 }


### PR DESCRIPTION
Tests to go along with pelias/api#205. It uses our beloved statue of liberty query, but with an alpha3 filter. The USA filtered query should only return results in New York, while the FRA filtered query should only show ones in Paris.

Fixes pelias/api#112