### PR TITLE
Add confidence score test

### DIFF
--- a/test_cases/confidence_score.json
+++ b/test_cases/confidence_score.json
@@ -14,6 +14,10 @@
       "expected": {
         "properties": [
           {
+            "name": "1 West 72 Street",
+            "housenumber": "1",
+            "street": "West 72 Street",
+            "country_a": "USA",
             "postalcode": "10023"
           }
         ]

--- a/test_cases/confidence_score.json
+++ b/test_cases/confidence_score.json
@@ -1,0 +1,30 @@
+{
+  "name": "confidence score",
+  "priorityThresh": 5,
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "Julian",
+      "description": "This is an attempt to test that an address with zipcode that is found does not fail a 'deal breaker'",
+      "type": "dev",
+      "in": {
+        "text": "1 West 72nd St, New York, NY, 10023"
+      },
+      "expected": {
+        "properties": [
+          {
+            "postalcode": "10023"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "confidence": 0.5
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This test lists a confidence score of 0.5 as an unexpected property. We
don't have > or < comparisons in our test suite, but I think the odds of
a well formed address query that we have good data for being given a
confidence score of 0.5, other than by hitting a deal-breaker (which
caps the score to exactly 0.5), is unlikely enough that this test will
work.

Fixes pelias/api#369