### PR TITLE
Autocomplete areas fix

### DIFF
--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -179,7 +179,11 @@
       "expected": {
         "properties": [
           {
-            "label": "Madrid, Spain"
+            "locality": "Madrid",
+            "region": "Madrid",
+            "country": "Spain"
+
+
           }
         ]
       }

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -93,10 +93,14 @@
       "expected": {
         "properties": [
           {
-            "label": "Victoria, Australia"
+            "region": "Victoria",
+            "country": "Australia"
           },
           {
-            "label": "Victoria, VICTORIA, Canada"
+            "locality": "VICTORIA",
+            "region": "British Columbia",
+            "country": "Canada"
+
           }
         ]
       }

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -94,12 +94,14 @@
         "properties": [
           {
             "region": "Victoria",
-            "country": "Australia"
+            "country": "Australia",
+            "layer": "region"
           },
           {
             "locality": "VICTORIA",
             "region": "British Columbia",
-            "country": "Canada"
+            "country": "Canada",
+            "layer": "locality"
 
           }
         ]
@@ -181,7 +183,8 @@
           {
             "locality": "Madrid",
             "region": "Madrid",
-            "country": "Spain"
+            "country": "Spain",
+            "layer": "locality"
 
 
           }


### PR DESCRIPTION
Fixes to Autocomplete admin areas tests needed so we can move pelias/api#378 & pelias/schema#84 into production.

These tests do not change the contents being returned, they just accept a broader set of valid labels for the place.

NOTES:
* [Victoria tests](https://github.com/pelias/acceptance-tests/commit/9971f8b6ad747d8b15157487f3792ab775f80d76#diff-6cbcf8faa91cd82ddffde879e25ca8da) name the city of Victoria "VICTORIA" due to a data issue in Quattroshapes. At present, this appears to be [resolved in Who's on First](https://github.com/whosonfirst/whosonfirst-data/commit/a0f71eb491bddc36a09ae379bce271e78eb14513)