### PR TITLE
Change "Vista Center" test back to pass

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -296,10 +296,9 @@
     },
     {
       "id": "13",
-      "status": "fail",
+      "status": "pass",
       "description": [
-        "all words in query text are address stop-words,",
-        "so must condition in query is actually a blank string"
+        "all words in query text are potential address stop-words"
       ],
       "issue": "https://github.com/pelias/api/issues/357",
       "type": "dev",


### PR DESCRIPTION
Now that Vista and center are no longer stop words, this test passes!