### PR TITLE
minimal sf test

### DIFF
--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -69,16 +69,10 @@
       "expected": {
         "properties": [
           {
-            "label": "San Francisco, San Francisco County, CA"
-          },
-          {
-            "label": "San Francisco Bay Area, San Francisco, CA"
-          },
-          {
-            "label": "San Francisco County, CA"
-          },
-          {
-            "label": "City of San Francisco, San Francisco, CA"
+            "region": "California",
+            "county": "San Francisco County",
+            "locality": "San Francisco",
+            "layer": "locality"
           }
         ]
       }


### PR DESCRIPTION
Redefines Autocomplete Admin Areas test for San Francisco to work from document properties, and not just the label, making it less brittle.

Accepts anything that's a `locality` named `San Francisco` in `county: San Francisco County`, `region: California`.