### PR TITLE
Adds test cases for autocomplete term extension

### DIFF
--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -1,0 +1,346 @@
+{
+  "name": "Autocomplete Streets",
+  "priorityThresh": 1,
+  "endpoint": "autocomplete",
+  "notes": "When searching for an address, after an abbreviation for the place has been typed, continuing to type the placename should improve or keep the top result as the same (e.g. st, stre, street). Related to: https://github.com/pelias/pelias/issues/165",
+  "tests": [
+    {
+      "id": "1-1",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "90 Vermilyea"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "90",
+            "street": "Vermilyea Avenue",
+            "locality": "New York",
+            "region": "New York",
+            "postalcode": "10034"
+          }
+        ]
+      }
+    },
+    {
+      "id": "1-2",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "90 Vermilyea A"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "90",
+            "street": "Vermilyea Avenue",
+            "locality": "New York",
+            "region": "New York",
+            "postalcode": "10034"
+          }
+        ]
+      }
+    },
+    {
+      "id": "1-2",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "90 Vermilyea Av"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "90",
+            "street": "Vermilyea Avenue",
+            "locality": "New York",
+            "region": "New York",
+            "postalcode": "10034"
+          }
+        ]
+      }
+    },
+    {
+      "id": "1-3",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "90 Vermilyea Ave"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "90",
+            "street": "Vermilyea Avenue",
+            "locality": "New York",
+            "region": "New York",
+            "postalcode": "10034"
+          }
+        ]
+      }
+    },
+    {
+      "id": "1-4",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "90 Vermilyea Aven"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "90",
+            "street": "Vermilyea Avenue",
+            "locality": "New York",
+            "region": "New York",
+            "postalcode": "10034"
+          }
+        ]
+      }
+    },
+    {
+      "id": "1-5",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "90 Vermilyea Avenue"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "90",
+            "street": "Vermilyea Avenue",
+            "locality": "New York",
+            "region": "New York",
+            "postalcode": "10034"
+          }
+        ]
+      }
+    },
+    {
+      "id": "2-1",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "424 Clay Av"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "424",
+            "street": "Clay Avenue",
+            "locality": "Waco",
+            "region": "Texas"
+          }
+        ]
+      }
+    },
+    {
+      "id": "2-2",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "424 Clay Ave"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "424",
+            "street": "Clay Avenue",
+            "locality": "Waco",
+            "region": "Texas"
+          }
+        ]
+      }
+    },
+    {
+      "id": "2-3",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "424 Clay Avenu"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "424",
+            "street": "Clay Avenue",
+            "locality": "Waco",
+            "region": "Texas"
+          }
+        ]
+      }
+    },
+    {
+      "id": "2-4",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "424 Clay Avenue"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "424",
+            "street": "Clay Avenue",
+            "locality": "Waco",
+            "region": "Texas"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3-1",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "198 Baker St",
+        "focus.point.lat": 42.102222,
+        "focus.point.lon": -75.911667
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "198",
+            "street": "Baker Street",
+            "locality": "Corning",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3-2",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "198 Baker Str",
+        "focus.point.lat": 42.102222,
+        "focus.point.lon": -75.911667
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "198",
+            "street": "Baker Street",
+            "locality": "Corning",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3-3",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "198 Baker Stre",
+        "focus.point.lat": 42.102222,
+        "focus.point.lon": -75.911667
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "198",
+            "street": "Baker Street",
+            "locality": "Corning",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3-4",
+      "status": "pass",
+      "user": "riordan",
+      "in": {
+        "text": "198 Baker Street",
+        "focus.point.lat": 42.102222,
+        "focus.point.lon": -75.911667
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "198",
+            "street": "Baker Street",
+            "locality": "Corning",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": "4-1",
+      "status": "fail",
+      "user": "riordan",
+      "in": {
+        "text": "451 Fog Hill"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "451",
+            "street": "Fog Hill Road",
+            "locality": "Austerlitz",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": "4-2",
+      "status": "fail",
+      "user": "riordan",
+      "in": {
+        "text": "451 Fog Hill rd"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "451",
+            "street": "Fog Hill Road",
+            "locality": "Austerlitz",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": "4-3",
+      "status": "fail",
+      "user": "riordan",
+      "in": {
+        "text": "451 Fog Hill Road"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "451",
+            "street": "Fog Hill Road",
+            "locality": "Austerlitz",
+            "region": "New York"
+          }
+        ]
+      }
+    }
+
+  ]
+}


### PR DESCRIPTION
Tests for pelias/api#372, which is part of Autocomplete Omnibus (pelias/pelias#165)  (pelias/api#378) / (pelias/schema#84)

Fixes pelias/api#372 (since the only thing left is tests)