### PR TITLE
The ultimate SF and Brooklyn test suite

### DIFF
--- a/test_cases/brooklyn.json
+++ b/test_cases/brooklyn.json
@@ -30,7 +30,7 @@
         "layers": "locality",
         "boundary.country": "USA"
       },
-      "expected": {
+      "unexpected": {
         "properties": [
           {
             "name": "Brooklyn",
@@ -88,7 +88,7 @@
         "layers": "locality",
         "boundary.country": "USA"
       },
-      "expected": {
+      "unexpected": {
         "properties": [
           {
             "name": "Brooklyn",
@@ -105,8 +105,116 @@
       "endpoint": "autocomplete",
       "in": {
         "text": "brooklyn",
-        "layers": "locality,localadmin",
-        "boundary.country": "USA"
+        "layers": "locality,localadmin"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Brooklyn",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "text": "brooklyn"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Brooklyn",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "text": "brooklyn",
+        "layers": "locality"
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "Brooklyn",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "text": "brooklyn",
+        "layers": "locality,localadmin"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Brooklyn",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "endpoint": "autocomplete",
+      "in": {
+        "text": "brooklyn"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Brooklyn",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "endpoint": "autocomplete",
+      "in": {
+        "text": "brooklyn",
+        "layers": "locality"
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "Brooklyn",
+            "region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "endpoint": "autocomplete",
+      "in": {
+        "text": "brooklyn",
+        "layers": "locality,localadmin"
       },
       "expected": {
         "properties": [

--- a/test_cases/brooklyn.json
+++ b/test_cases/brooklyn.json
@@ -1,0 +1,121 @@
+{
+  "name": "Brooklyn",
+  "priorityThresh": 1,
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "text": "brooklyn",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+			"name": "Brooklyn",
+			"region": "New York"
+          }
+        ]
+      }
+    },
+	{
+      "id": 2,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "text": "brooklyn",
+		"layers": "locality",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+			"name": "Brooklyn",
+			"region": "New York"
+          }
+        ]
+      }
+    },
+	{
+      "id": 3,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "text": "brooklyn",
+		"layers": "locality,localadmin",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+			"name": "Brooklyn",
+			"region": "New York"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+	  "endpoint": "autocomplete",
+      "in": {
+        "text": "brooklyn",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+			"name": "Brooklyn",
+			"region": "New York"
+          }
+        ]
+      }
+    },
+	{
+      "id": 5,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+	  "endpoint": "autocomplete",
+      "in": {
+        "text": "brooklyn",
+		"layers": "locality",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+			"name": "Brooklyn",
+			"region": "New York"
+          }
+        ]
+      }
+    },
+	{
+      "id": 6,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+	  "endpoint": "autocomplete",
+      "in": {
+        "text": "brooklyn",
+		"layers": "locality,localadmin",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+			"name": "Brooklyn",
+			"region": "New York"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test_cases/brooklyn.json
+++ b/test_cases/brooklyn.json
@@ -9,51 +9,51 @@
       "type": "dev",
       "in": {
         "text": "brooklyn",
-		"boundary.country": "USA"
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
           {
-			"name": "Brooklyn",
-			"region": "New York"
+            "name": "Brooklyn",
+            "region": "New York"
           }
         ]
       }
     },
-	{
+    {
       "id": 2,
       "status": "pass",
       "user": "Julian",
       "type": "dev",
       "in": {
         "text": "brooklyn",
-		"layers": "locality",
-		"boundary.country": "USA"
+        "layers": "locality",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
           {
-			"name": "Brooklyn",
-			"region": "New York"
+            "name": "Brooklyn",
+            "region": "New York"
           }
         ]
       }
     },
-	{
+    {
       "id": 3,
       "status": "pass",
       "user": "Julian",
       "type": "dev",
       "in": {
         "text": "brooklyn",
-		"layers": "locality,localadmin",
-		"boundary.country": "USA"
+        "layers": "locality,localadmin",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
           {
-			"name": "Brooklyn",
-			"region": "New York"
+            "name": "Brooklyn",
+            "region": "New York"
           }
         ]
       }
@@ -63,56 +63,56 @@
       "status": "pass",
       "user": "Julian",
       "type": "dev",
-	  "endpoint": "autocomplete",
+      "endpoint": "autocomplete",
       "in": {
         "text": "brooklyn",
-		"boundary.country": "USA"
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
           {
-			"name": "Brooklyn",
-			"region": "New York"
+            "name": "Brooklyn",
+            "region": "New York"
           }
         ]
       }
     },
-	{
+    {
       "id": 5,
       "status": "pass",
       "user": "Julian",
       "type": "dev",
-	  "endpoint": "autocomplete",
+      "endpoint": "autocomplete",
       "in": {
         "text": "brooklyn",
-		"layers": "locality",
-		"boundary.country": "USA"
+        "layers": "locality",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
           {
-			"name": "Brooklyn",
-			"region": "New York"
+            "name": "Brooklyn",
+            "region": "New York"
           }
         ]
       }
     },
-	{
+    {
       "id": 6,
       "status": "pass",
       "user": "Julian",
       "type": "dev",
-	  "endpoint": "autocomplete",
+      "endpoint": "autocomplete",
       "in": {
         "text": "brooklyn",
-		"layers": "locality,localadmin",
-		"boundary.country": "USA"
+        "layers": "locality,localadmin",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
           {
-			"name": "Brooklyn",
-			"region": "New York"
+            "name": "Brooklyn",
+            "region": "New York"
           }
         ]
       }

--- a/test_cases/brooklyn.json
+++ b/test_cases/brooklyn.json
@@ -59,7 +59,7 @@
       }
     },
     {
-      "id": 4,
+      "id": "4-autocomplete",
       "status": "pass",
       "user": "Julian",
       "type": "dev",
@@ -82,13 +82,10 @@
       "status": "pass",
       "user": "Julian",
       "type": "dev",
-      "endpoint": "autocomplete",
       "in": {
-        "text": "brooklyn",
-        "layers": "locality",
-        "boundary.country": "USA"
+        "text": "brooklyn"
       },
-      "unexpected": {
+      "expected": {
         "properties": [
           {
             "name": "Brooklyn",
@@ -102,12 +99,11 @@
       "status": "pass",
       "user": "Julian",
       "type": "dev",
-      "endpoint": "autocomplete",
       "in": {
         "text": "brooklyn",
-        "layers": "locality,localadmin"
+        "layers": "locality"
       },
-      "expected": {
+      "unexpected": {
         "properties": [
           {
             "name": "Brooklyn",
@@ -122,41 +118,6 @@
       "user": "Julian",
       "type": "dev",
       "in": {
-        "text": "brooklyn"
-      },
-      "expected": {
-        "properties": [
-          {
-            "name": "Brooklyn",
-            "region": "New York"
-          }
-        ]
-      }
-    },
-    {
-      "id": 8,
-      "status": "pass",
-      "user": "Julian",
-      "type": "dev",
-      "in": {
-        "text": "brooklyn",
-        "layers": "locality"
-      },
-      "unexpected": {
-        "properties": [
-          {
-            "name": "Brooklyn",
-            "region": "New York"
-          }
-        ]
-      }
-    },
-    {
-      "id": 9,
-      "status": "pass",
-      "user": "Julian",
-      "type": "dev",
-      "in": {
         "text": "brooklyn",
         "layers": "locality,localadmin"
       },
@@ -170,51 +131,13 @@
       }
     },
     {
-      "id": 10,
+      "id": "8-autocomplete",
       "status": "pass",
       "user": "Julian",
       "type": "dev",
       "endpoint": "autocomplete",
       "in": {
         "text": "brooklyn"
-      },
-      "expected": {
-        "properties": [
-          {
-            "name": "Brooklyn",
-            "region": "New York"
-          }
-        ]
-      }
-    },
-    {
-      "id": 11,
-      "status": "pass",
-      "user": "Julian",
-      "type": "dev",
-      "endpoint": "autocomplete",
-      "in": {
-        "text": "brooklyn",
-        "layers": "locality"
-      },
-      "unexpected": {
-        "properties": [
-          {
-            "name": "Brooklyn",
-            "region": "New York"
-          }
-        ]
-      }
-    },
-    {
-      "id": 12,
-      "status": "pass",
-      "user": "Julian",
-      "type": "dev",
-      "endpoint": "autocomplete",
-      "in": {
-        "text": "brooklyn",
-        "layers": "locality,localadmin"
       },
       "expected": {
         "properties": [

--- a/test_cases/san_francisco.json
+++ b/test_cases/san_francisco.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "id": 4,
+      "id": "4-autocomplete",
       "status": "pass",
       "user": "Julian",
       "endpoint": "autocomplete",
@@ -77,11 +77,8 @@
       "id": 5,
       "status": "pass",
       "user": "Julian",
-      "endpoint": "autocomplete",
       "in": {
-        "text": "san francisco",
-        "layers": "locality",
-        "boundary.country": "USA"
+        "text": "san francisco"
       },
       "expected": {
         "properties": [
@@ -96,11 +93,43 @@
       "id": 6,
       "status": "pass",
       "user": "Julian",
-      "endpoint": "autocomplete",
       "in": {
         "text": "san francisco",
-        "layers": "locality,localadmin",
-        "boundary.country": "USA"
+        "layers": "locality"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "san francisco",
+        "layers": "locality,localadmin"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": "8-autocomplete",
+      "status": "pass",
+      "user": "Julian",
+      "endpoint": "autocomplete",
+      "in": {
+        "text": "san francisco"
       },
       "expected": {
         "properties": [

--- a/test_cases/san_francisco.json
+++ b/test_cases/san_francisco.json
@@ -1,0 +1,115 @@
+{
+  "name": "San Francisco",
+  "priorityThresh": 1,
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "san francisco",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "san francisco",
+		"layers": "locality",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "Julian",
+      "in": {
+        "text": "san francisco",
+		"layers": "locality,localadmin",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "Julian",
+	  "endpoint": "autocomplete",
+      "in": {
+        "text": "san francisco",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "Julian",
+	  "endpoint": "autocomplete",
+      "in": {
+        "text": "san francisco",
+		"layers": "locality",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "user": "Julian",
+	  "endpoint": "autocomplete",
+      "in": {
+        "text": "san francisco",
+		"layers": "locality,localadmin",
+		"boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test_cases/san_francisco.json
+++ b/test_cases/san_francisco.json
@@ -21,7 +21,7 @@
     },
     {
       "id": 2,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -39,7 +39,7 @@
     },
     {
       "id": 3,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -57,7 +57,7 @@
     },
     {
       "id": "4-autocomplete",
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "endpoint": "autocomplete",
       "in": {
@@ -91,7 +91,7 @@
     },
     {
       "id": 6,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -108,7 +108,7 @@
     },
     {
       "id": 7,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -125,7 +125,7 @@
     },
     {
       "id": "8-autocomplete",
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "endpoint": "autocomplete",
       "in": {

--- a/test_cases/san_francisco.json
+++ b/test_cases/san_francisco.json
@@ -8,7 +8,7 @@
       "user": "Julian",
       "in": {
         "text": "san francisco",
-		"boundary.country": "USA"
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
@@ -25,8 +25,8 @@
       "user": "Julian",
       "in": {
         "text": "san francisco",
-		"layers": "locality",
-		"boundary.country": "USA"
+        "layers": "locality",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
@@ -43,8 +43,8 @@
       "user": "Julian",
       "in": {
         "text": "san francisco",
-		"layers": "locality,localadmin",
-		"boundary.country": "USA"
+        "layers": "locality,localadmin",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
@@ -59,10 +59,10 @@
       "id": 4,
       "status": "pass",
       "user": "Julian",
-	  "endpoint": "autocomplete",
+      "endpoint": "autocomplete",
       "in": {
         "text": "san francisco",
-		"boundary.country": "USA"
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
@@ -77,11 +77,11 @@
       "id": 5,
       "status": "pass",
       "user": "Julian",
-	  "endpoint": "autocomplete",
+      "endpoint": "autocomplete",
       "in": {
         "text": "san francisco",
-		"layers": "locality",
-		"boundary.country": "USA"
+        "layers": "locality",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [
@@ -96,11 +96,11 @@
       "id": 6,
       "status": "pass",
       "user": "Julian",
-	  "endpoint": "autocomplete",
+      "endpoint": "autocomplete",
       "in": {
         "text": "san francisco",
-		"layers": "locality,localadmin",
-		"boundary.country": "USA"
+        "layers": "locality,localadmin",
+        "boundary.country": "USA"
       },
       "expected": {
         "properties": [


### PR DESCRIPTION
Test all combinations of
layers=locality/layers=locality,localadmin/layers=[unset] against the
search and autocomplete endpoints for SF and Brooklyn.
boundary.country=USA is set for all tests.