### PR TITLE
Local autocomplete not finding 1 Madison Ave

### DIFF
--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -120,6 +120,32 @@
           }
         ]
       }
+    },
+    {
+      "id": 25,
+      "status": "fail",
+      "user": "randyme",
+      "notes": [ "Autocomplete is not prioritizing local address.",
+      "Issue filed in: https://github.com/pelias/pelias/issues/240" ],
+      "in": {
+        "focus.point.lat": 40.744131,
+        "focus.point.lon": -73.990424,
+        "text": "1 madison ave"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          {
+            "name": "1 Madison Avenue",
+            "layer": "address",
+            "housenumber": "1",
+            "street": "Madison Avenue",
+            "region": "New York",
+            "localadmin": "Manhattan",
+            "locality": "New York"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
@randymeech ran into this incident while doing a demo. Not good when it can't find the building you're in.

Found in pelias/pelias#240

[Compare Link](http://pelias.github.io/compare/#/v1/autocomplete%3Ffocus.point.lat=40.744131&focus.point.lon=-73.990424&text=1%20madison%20ave)