### PR TITLE
increase priorityThresh to 3 for autocomplete_streets.json

### DIFF
--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -1,6 +1,6 @@
 {
   "name": "Autocomplete Streets",
-  "priorityThresh": 1,
+  "priorityThresh": 3,
   "endpoint": "autocomplete",
   "notes": "When searching for an address, after an abbreviation for the place has been typed, continuing to type the placename should improve or keep the top result as the same (e.g. st, stre, street). Related to: https://github.com/pelias/pelias/issues/165",
   "tests": [

--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -1,6 +1,6 @@
 {
   "name": "Autocomplete Streets",
-  "priorityThresh": 3,
+  "priorityThresh": 1,
   "endpoint": "autocomplete",
   "notes": "When searching for an address, after an abbreviation for the place has been typed, continuing to type the placename should improve or keep the top result as the same (e.g. st, stre, street). Related to: https://github.com/pelias/pelias/issues/165",
   "tests": [
@@ -16,10 +16,7 @@
           {
             "layer": "address",
             "housenumber": "90",
-            "street": "Vermilyea Avenue",
-            "locality": "New York",
-            "region": "New York",
-            "postalcode": "10034"
+            "street": "Vermilyea Avenue"
           }
         ]
       }
@@ -36,10 +33,7 @@
           {
             "layer": "address",
             "housenumber": "90",
-            "street": "Vermilyea Avenue",
-            "locality": "New York",
-            "region": "New York",
-            "postalcode": "10034"
+            "street": "Vermilyea Avenue"
           }
         ]
       }
@@ -56,10 +50,7 @@
           {
             "layer": "address",
             "housenumber": "90",
-            "street": "Vermilyea Avenue",
-            "locality": "New York",
-            "region": "New York",
-            "postalcode": "10034"
+            "street": "Vermilyea Avenue"
           }
         ]
       }
@@ -76,10 +67,7 @@
           {
             "layer": "address",
             "housenumber": "90",
-            "street": "Vermilyea Avenue",
-            "locality": "New York",
-            "region": "New York",
-            "postalcode": "10034"
+            "street": "Vermilyea Avenue"
           }
         ]
       }
@@ -96,10 +84,7 @@
           {
             "layer": "address",
             "housenumber": "90",
-            "street": "Vermilyea Avenue",
-            "locality": "New York",
-            "region": "New York",
-            "postalcode": "10034"
+            "street": "Vermilyea Avenue"
           }
         ]
       }
@@ -116,10 +101,7 @@
           {
             "layer": "address",
             "housenumber": "90",
-            "street": "Vermilyea Avenue",
-            "locality": "New York",
-            "region": "New York",
-            "postalcode": "10034"
+            "street": "Vermilyea Avenue"
           }
         ]
       }


### PR DESCRIPTION
a test was failing on production, the case had a `priorityThresh` of 1, so I changed it to 3.

it seems like in the past for the query `/v1/autocomplete?text=424 Clay Av` the top result was:

```
424 Clay Avenue, Waco, TX
```

... and now the order on production is:

```
1)	424 Clay Avenue, Rochester, NY
2)	424 Clay Avenue, Waco, TX
3)	424 Clay Avenue, Bonhomme, MO
4)	424 Henry Clay Avenue, New Orleans, LA
```

... and on prodbuild it is:

```
1)	424 Clay Avenue, Bonhomme, MO
2)	424 Clay Avenue, Waco, TX
3)	424 Clay Avenue, Rochester, NY
4)	424 Henry Clay Avenue, New Orleans, LA
```

... and on dev it is:

```
1)	424 Clay Avenue, Bonhomme, Missouri
2)	424 Clay Avenue, Rochester, New York
3)	424 Clay Avenue, Waco, Texas
4)	424 Henry Clay Avenue, New Orleans, Louisiana
```

it seems to vary depending on which order the documents were imported, and without a tiebreaker it's not going to be deterministic.

cc/ @riordan, is this fine with you or did you want the test to ensure this record was always first?