### PR TITLE
Remove source field from admin lookup test

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -448,8 +448,7 @@
             "country": "United States",
             "region": "California",
             "region_a": "CA",
-            "label": "California, USA",
-            "source": "whosonfirst"
+            "label": "California, USA"
           }
         ]
       }


### PR DESCRIPTION
This test isn't concerned with individual sources. While ideally we
would want the WOF record first, the Geonames record is also fine.