### PR TITLE
Remove "Brooklyn, King's County" expected value

### DIFF
--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -33,9 +33,6 @@
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
-          },
-          {
-            "label": "Brooklyn, Kings County, NY, USA"
           }
         ]
       }


### PR DESCRIPTION
Brooklyn IS King's County, so I suspect this expectation was just here
because it was a result we returned. Our label generation is better now.