### PR TITLE
Improve Mission District, SF test

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -134,13 +134,14 @@
       "status": "pass",
       "type": "dev",
       "in": {
-        "text": "mission, ca",
+        "text": "mission, san francisco",
         "layers": "coarse"
       },
       "expected": {
         "properties": [
           {
             "name": "Mission",
+            "layer": "neighbourhood",
             "country_a": "USA",
             "country": "United States",
             "region": "California",


### PR DESCRIPTION
A search query for "mission, CA" is both not very specific, and probably
not how anyone in SF would search for the Mission.