### PR TITLE
Add test cases for missing and incorrect postcodes

### DIFF
--- a/test_cases/missing_postcodes.json
+++ b/test_cases/missing_postcodes.json
@@ -1,0 +1,59 @@
+{
+  "name": "missing postcodes",
+  "priorityThresh": 3,
+  "endpoint": "search",
+  "tests": [
+    {
+      "id": 1,
+      "status": "fail",
+      "user": "Julian",
+      "type": "dev",
+      "notes": "Correct zipcode is 10009",
+      "in": {
+        "text": "267 e 10th st, new york, ny 10010"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "267 East 10th Street",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "New York",
+            "region_a": "NY",
+            "county": "New York County",
+            "localadmin": "Manhattan",
+            "locality": "New York",
+            "neighbourhood": "East Village",
+            "housenumber": "267",
+            "street": "East 10th Street"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "fail",
+      "user": "Julian",
+      "type": "dev",
+      "notes": "Desired document has no zipcode, but should be 33801. If we ever get better data, find a new test case",
+      "in": {
+        "text": "440 S Combee Rd, Lakeland, FL 33801"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "440 South Combee Road",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "Florida",
+            "region_a": "FL",
+            "county": "Polk County",
+            "locality": "Crystal Lake",
+            "housenumber": "440",
+            "street": "South Combee Road"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The first test is a case where the user has entered an incorrect, but
nearby zipcode for a document where we have the correct zipcode. We
should be able to figure things out anyways.

The second test has the user enter the correct zipcode, but the correct
document is missing zipcode info. We should also handle this just fine.