### PR TITLE
Label fixes

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -26,7 +26,7 @@
             "postalcode": "10009",
             "housenumber": "101",
             "street": "Saint Marks Place",
-            "label": "101 Saint Marks Place, Manhattan, NY, USA"
+            "label": "101 Saint Marks Place, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -48,7 +48,7 @@
       "expected": {
         "properties": [
           {
-            "label": "1 Water Street, Manhattan, NY, USA"
+            "label": "1 Water Street, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -64,7 +64,7 @@
       "expected": {
         "properties": [
           {
-            "label": "1 Water Street, Manhattan, NY, USA"
+            "label": "1 Water Street, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -93,7 +93,7 @@
             "postalcode": "11232",
             "housenumber": "450",
             "street": "37th Street",
-            "label": "450 37th Street, Brooklyn, NY, USA"
+            "label": "450 37th Street, Brooklyn, New York, NY, USA"
           }
         ]
       },
@@ -128,7 +128,7 @@
             "postalcode": "10010",
             "housenumber": "304",
             "street": "Park Avenue South",
-            "label": "Starbucks, Manhattan, NY, USA"
+            "label": "Starbucks, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -156,7 +156,7 @@
             "postalcode": "11232",
             "housenumber": "455",
             "street": "43rd Street",
-            "label": "455 43rd Street, Brooklyn, NY, USA"
+            "label": "455 43rd Street, Brooklyn, New York, NY, USA"
           }
         ]
       }
@@ -184,7 +184,7 @@
             "postalcode": "11201",
             "housenumber": "1",
             "street": "Main Street",
-            "label": "1 Main Street, Brooklyn, NY, USA"
+            "label": "1 Main Street, Brooklyn, New York, NY, USA"
           }
         ]
       }

--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -165,7 +165,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Crown Heights, Brooklyn, NY, USA",
+            "label": "Crown Heights, Brooklyn, New York, NY, USA",
             "name": "Crown Heights",
             "country_a": "USA",
             "country": "United States",
@@ -187,7 +187,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Palo Alto, Santa Clara County, CA, USA"
+            "label": "Palo Alto, CA, USA"
           }
         ]
       }
@@ -202,7 +202,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Palo Alto, Santa Clara County, CA, USA"
+            "label": "Palo Alto, CA, USA"
           }
         ]
       }

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -292,7 +292,7 @@
         "priorityThresh": 1,
         "properties": [
           {
-            "label": "Malmö, Skåne, Sweden"
+            "label": "Malmö, Sweden"
           }
         ]
       }

--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -16,7 +16,7 @@
       "expected": {
         "properties": [
           {
-            "label": "DiDi Dumpling, Manhattan, NY, USA"
+            "label": "DiDi Dumpling, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -96,7 +96,7 @@
         "priorityThresh": 1,
         "properties": [
           {
-            "label": "Hard Rock Cafe, Manhattan, NY, USA"
+            "label": "Hard Rock Cafe, Manhattan, New York, NY, USA"
           }
         ]
       }

--- a/test_cases/autocomplete_venues.json
+++ b/test_cases/autocomplete_venues.json
@@ -14,7 +14,7 @@
       "expected": {
         "properties": [
           {
-            "label": "DiDi Dumpling, Manhattan, NY, USA"
+            "label": "DiDi Dumpling, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -29,7 +29,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Hackney City Farm, Haggerston, United Kingdom"
+            "label": "Hackney City Farm, London, England, United Kingdom"
           }
         ]
       }
@@ -76,7 +76,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Waiotapu, Rotorua District, New Zealand"
+            "label": "Waiotapu, New Zealand"
           }
         ]
       }

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -183,6 +183,19 @@
           "label": "McDonald's, Singapore, Singapore"
         }]
       }
+    },
+    {
+      "id": 14,
+      "status": "pass",
+      "user": "julian",
+      "in": {
+        "text": "France"
+      },
+      "expected": {
+        "properties": [{
+          "label": "France"
+        }]
+      }
     }
   ]
 }

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -12,7 +12,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "San Francisco, San Francisco County, CA, USA"
+          "label": "San Francisco, CA, USA"
         }]
       }
     },
@@ -25,7 +25,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "30 West 26th Street, Manhattan, NY, USA"
+          "label": "30 West 26th Street, Manhattan, New York, NY, USA"
         }]
       }
     },
@@ -141,7 +141,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "Hackney City Farm, Haggerston, United Kingdom"
+          "label": "Hackney City Farm, London, England, United Kingdom"
         }]
       }
     },
@@ -180,7 +180,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "McDonald's, Central Singapore, Singapore"
+          "label": "McDonald's, Singapore, Singapore"
         }]
       }
     }

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -101,9 +101,7 @@
     },
     {
       "id": 8,
-      "status": "fail",
-      "issue": "https://github.com/pelias/pelias/issues/299",
-      "description": "label generation might need to be tweaked",
+      "status": "pass",
       "user": "missinglink",
       "in": {
         "text": "Madrid, Spain"

--- a/test_cases/quattroshapes_popularity.json
+++ b/test_cases/quattroshapes_popularity.json
@@ -16,7 +16,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Chelsea, Manhattan, NY, USA"
+            "label": "Chelsea, Manhattan, New York, NY, USA"
           },
           {
             "label": "Chelsea, London, United Kingdom"
@@ -37,7 +37,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Chelsea, Manhattan, NY, USA"
+            "label": "Chelsea, Manhattan, New York, NY, USA"
           }
         ]
       }
@@ -54,7 +54,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Williamsburg, Brooklyn, NY, USA"
+            "label": "Williamsburg, Brooklyn, New York, NY, USA"
           }
         ]
       }
@@ -71,7 +71,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Williamsburg, Brooklyn, NY, USA"
+            "label": "Williamsburg, Brooklyn, New York, NY, USA"
           }
         ]
       }
@@ -88,7 +88,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Ridgewood, Queens, NY, USA"
+            "label": "Ridgewood, Queens, New York, NY, USA"
           },
           {
             "label": "Ridgewood, Bergen County, NJ, USA"
@@ -108,7 +108,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Ridgewood, Queens, NY, USA"
+            "label": "Ridgewood, Queens, New York, NY, USA"
           }
         ]
       }

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -45,7 +45,9 @@
       "expected": {
         "properties": [
           {
-            "label": "Philadelphia, Philadelphia County, PA, USA"
+            "name": "Philadelphia",
+            "region": "Pennsylvania",
+            "country_a": "USA"
           }
         ]
       }
@@ -61,7 +63,9 @@
       "expected": {
         "properties": [
           {
-            "label": "Philadelphia, Philadelphia County, PA, USA"
+            "name": "Philadelphia",
+            "region": "Pennsylvania",
+            "country_a": "USA"
           }
         ]
       }
@@ -77,10 +81,16 @@
       "expected": {
         "properties": [
           {
-            "label": "New York County, NY, USA"
+            "name": "New York County",
+            "layer": "county",
+            "region_a": "NY",
+            "country_a": "USA"
           },
           {
-            "label": "New York City, New York, NY, USA"
+            "name": "New York City",
+            "layer": "locality",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -96,7 +106,10 @@
       "expected": {
         "properties": [
           {
-            "label": "New York City, New York, NY, USA"
+            "name": "New York City",
+            "layer": "locality",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -112,7 +125,10 @@
       "expected": {
         "properties": [
           {
-            "label": "New York City, New York, NY, USA"
+            "name": "New York City",
+            "layer": "locality",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -128,7 +144,11 @@
       "expected": {
         "properties": [
           {
-            "label": "130 Dean Street, Brooklyn, NY, USA"
+            "name": "130 Dean Street",
+            "borough": "Brooklyn",
+            "locality": "New York",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -144,7 +164,10 @@
       "expected": {
         "properties": [
           {
-            "label": "Billerica, Middlesex County, MA, USA"
+            "name": "Billerica",
+            "county": "Middlesex County",
+            "region_a": "MA",
+            "country_a": "USA"
           }
         ]
       }
@@ -160,7 +183,10 @@
       "expected": {
         "properties": [
           {
-            "label": "Billerica, Middlesex County, MA, USA"
+            "name": "Billerica",
+            "county": "Middlesex County",
+            "region_a": "MA",
+            "country_a": "USA"
           }
         ]
       }
@@ -180,7 +206,8 @@
             "country": "United States",
             "region": "Massachusetts",
             "county": "Middlesex County",
-            "label": "15 Call Street, Billerica, MA, USA"
+            "region_a": "MA",
+            "country_a": "USA"
           }
         ]
       }
@@ -222,7 +249,10 @@
       "expected": {
         "properties": [
           {
-            "label": "Portland, Multnomah County, OR, USA"
+            "name": "Portland",
+            "county": "Multnomah County",
+            "region_a": "OR",
+            "country_a": "USA"
           }
         ]
       }
@@ -238,7 +268,10 @@
       "expected": {
         "properties": [
           {
-            "label": "Portland, Multnomah County, OR, USA"
+            "name": "Portland",
+            "county": "Multnomah County",
+            "region_a": "OR",
+            "country_a": "USA"
           }
         ]
       }
@@ -255,7 +288,8 @@
       "expected": {
         "properties": [
           {
-            "label": "Paris, France"
+            "name": "Paris",
+            "country": "France"
           }
         ]
       }
@@ -274,7 +308,7 @@
       "expected": {
         "properties": [
           {
-            "label": "France"
+            "name": "France"
           }
         ]
       }
@@ -314,7 +348,11 @@
       "expected": {
         "properties": [
           {
-            "label": "Chelsea, Manhattan, NY, USA"
+            "name": "Chelsea",
+            "layer": "neighbourhood",
+            "borough": "Manhattan",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -330,7 +368,11 @@
       "expected": {
         "properties": [
           {
-            "label": "SoHo, Manhattan, NY, USA"
+            "name": "SoHo",
+            "layer": "neighbourhood",
+            "borough": "Manhattan",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -345,7 +387,9 @@
       "expected": {
         "properties": [
           {
-            "label": "Perugia San Francesco d'Assisi – Umbria International Airport, Perugia, Italy"
+            "name": "Perugia San Francesco d'Assisi – Umbria International Airport",
+            "region": "Perugia",
+            "country_a": "ITA"
           }
         ]
       }
@@ -361,8 +405,10 @@
       "expected": {
         "properties": [
           {
+            "name": "101 Saint Marks Place",
             "neighbourhood": "East Village",
-            "label": "101 Saint Marks Place, Manhattan, NY, USA"
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }
@@ -463,7 +509,6 @@
             "postalcode": "10010",
             "housenumber": "30",
             "street": "West 26th Street",
-            "label": "30 West 26th Street, Manhattan, NY, USA",
             "source": "openstreetmap"
           }
         ]

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -278,9 +278,7 @@
     },
     {
       "id": "1425586777012:3",
-      "status": "fail",
-      "issue": "https://github.com/pelias/pelias/issues/299",
-      "description": "label generation might need to be tweaked",
+      "status": "pass",
       "user": "feedback-app",
       "in": {
         "text": "paris"


### PR DESCRIPTION
Fix all the labels that are affected by pelias/api#497 and pelias/api#507

Note: I changed many of the search tests to avoid using labels, and moved a few label checks into the label test suite instead.