### PR TITLE
more tests for autocomplete milestone

### DIFF
--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -311,6 +311,40 @@
           }
         ]
       }
+    },
+    {
+      "id": 14,
+      "status": "pass",
+      "user": "missinglink",
+      "description": "partially complete major city name",
+      "issue": "https://github.com/pelias/pelias/issues/143",
+      "in": {
+        "text": "Pari"
+      },
+      "expected": {
+        "properties": [
+          {
+            "label": "Paris, France"
+          }
+        ]
+      }
+    },
+    {
+      "id": 15,
+      "status": "pass",
+      "user": "missinglink",
+      "description": "partially complete major city name",
+      "issue": "https://github.com/pelias/pelias/issues/143",
+      "in": {
+        "text": "Londo"
+      },
+      "expected": {
+        "properties": [
+          {
+            "label": "London, England, United Kingdom"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -146,6 +146,37 @@
           }
         ]
       }
+    },
+    {
+      "id": 26,
+      "status": "pass",
+      "user": "missinglink",
+      "notes": [
+        "tight markering clustering around focus.",
+        "when given a query which matches many results, the chosen results",
+        "should be as 'tightly' clustered around the focus point as possible",
+        "note: this test is not ideal, I would really like to confirm this:",
+        "http://missinglink.embed.s3.amazonaws.com/pelias_clustering.png",
+        "however the test suite doesn't currently support this behaviour."
+      ],
+      "in": {
+        "focus.point.lat": 40.744131,
+        "focus.point.lon": -73.990424,
+        "text": "w 26th st"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 100,
+        "properties": [
+          {
+            "region": "New York",
+            "borough": "Manhattan"
+          }
+        ],
+        "coordinates": [
+          [ -73.990424, 40.744131 ]
+        ]
+      }
     }
   ]
 }

--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -320,6 +320,36 @@
           }
         ]
       }
+    },
+    {
+      "id": "6",
+      "status": "pass",
+      "user": "missinglink",
+      "description": [ "house number provided in 3rd position instead of 1st" ],
+      "in": {
+        "text": "glasgow street 18, kelburn, wellington"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          { "label": "18 Glasgow Street, Wellington, New Zealand" }
+        ]
+      }
+    },
+    {
+      "id": "7",
+      "status": "pass",
+      "user": "missinglink",
+      "description": [ "house number provided in 3rd position instead of 1st" ],
+      "in": {
+        "text": "grolmanstrasse 51, charlottenburg, berlin"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          { "label": "Grolmanstraße 51, Berlin, Germany" }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/search_spelling_mistakes.json
+++ b/test_cases/search_spelling_mistakes.json
@@ -1,0 +1,23 @@
+{
+  "name": "search_spelling_mistakes",
+  "priorityThresh": 1,
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "missinglink",
+      "in": {
+        "text": "neu yorp"
+      },
+      "expected": {
+        "properties": [
+          { "name": "New York" },
+          { "name": "New York" },
+          { "name": "New York" },
+          { "name": "New York" },
+          { "name": "New York" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
more tests for autocomplete milestone

- [autocomplete] find Paris and London by partially completed tokens 'Pari' and 'Londo' (https://github.com/pelias/pelias/issues/143)
- [autocomplete] tighter focus clustering
- [autocomplete] allow users to specify the house number in the 1st 2nd or 3rd position 
- [search] find New York via misspelling "neu yorp"