### PR TITLE
test for query ending in single digit

### DIFF
--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -320,6 +320,29 @@
           }
         ]
       }
+    },
+    {
+      "id": "6",
+      "status": "pass",
+      "user": "missinglink",
+      "description": "query ending with a single digit",
+      "notes": [
+        "priorityThresh set to 5 as some sources contain the abbreviated",
+        "form Grolmanstr."
+      ],
+      "in": {
+        "text": "grolmanstr 1"
+      },
+      "expected": {
+        "priorityThresh": 5,
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "1",
+            "street": "Grolmanstraße"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
related: https://github.com/pelias/api/pull/526/commits/ca0c51b0fde45c3f863a516bc923bc122c68f7ee

prior to the above commit we would strip all trailing single tokens from a query; regardless of whether they were alpha or numeric.

in some recent changes to pelias/schema we have enabled the indexing of single numeric digits, this is in order to allow matching single digit house numbers.

this test ensures that the functionality mentioned above is working as expected and doesn't regress.

```
/v1/autocomplete?text=grolmanstr 8

# before
 1)	Grolmanstraße 1, Köln, Germany
 2)	Grolmanstraße 7, Köln, Germany
 3)	Grolmanstraße 1, Berlin, Germany
 4)	Grolmanstraße 4, Köln, Germany
 5)	Grolmanstraße 3, Köln, Germany
 6)	Grolmanstr. 9, Köln, Germany
 7)	Grolmanstraße 8, Bochum, Germany
 8)	Grolmanstr. 4, Köln, Germany
 9)	Grolmanstr. 8, Köln, Germany
10)	Grolmanstraße 6, Bochum, Germany

# after
1)	Grolmanstr. 8, Köln, Germany
2)	Grolmanstraße 8, Bochum, Germany
3)	Grolmanstraße 8, Köln, Germany
```