### PR TITLE
autocomplete and search tests for borough matching

### DIFF
--- a/test_cases/address_matching.json
+++ b/test_cases/address_matching.json
@@ -101,6 +101,21 @@
           }
         ]
       }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "missinglink",
+      "description": [ "borough matching, no delimiter" ],
+      "in": {
+        "text": "190 dean street brooklyn"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          { "label": "190 Dean Street, Brooklyn, New York, NY, USA" }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -373,6 +373,21 @@
           { "label": "Grolmanstraße 51, Berlin, Germany" }
         ]
       }
+    },
+    {
+      "id": "9",
+      "status": "pass",
+      "user": "missinglink",
+      "description": [ "borough matching, no delimiter" ],
+      "in": {
+        "text": "190 dean street brooklyn"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          { "label": "190 Dean Street, Brooklyn, New York, NY, USA" }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
These tests cover a bug where `borough` was not being correctly targeted during query execution.

the tests cover both `/v1/autocomplete` and `/v1/search`