### PR TITLE
Use borough field for New York City boroughs

### DIFF
--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -141,7 +141,7 @@
             "housenumber": "1",
             "street": "Madison Avenue",
             "region": "New York",
-            "localadmin": "Manhattan",
+            "borough": "Manhattan",
             "locality": "New York"
           }
         ]

--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -123,7 +123,7 @@
     },
     {
       "id": 25,
-      "status": "fail",
+      "status": "pass",
       "user": "randyme",
       "notes": [ "Autocomplete is not prioritizing local address.",
       "Issue filed in: https://github.com/pelias/pelias/issues/240" ],

--- a/test_cases/missing_postcodes.json
+++ b/test_cases/missing_postcodes.json
@@ -21,7 +21,7 @@
             "region": "New York",
             "region_a": "NY",
             "county": "New York County",
-            "localadmin": "Manhattan",
+            "borough": "Manhattan",
             "locality": "New York",
             "neighbourhood": "East Village",
             "housenumber": "267",

--- a/test_cases/poi_address_matching.json
+++ b/test_cases/poi_address_matching.json
@@ -23,7 +23,7 @@
             "street": "West 26th Street",
             "postalcode": "10010",
             "region_a": "NY",
-            "localadmin": "Manhattan",
+            "borough": "Manhattan",
             "locality": "New York",
             "label": "Samsung Accelerator, Manhattan, NY, USA"
           }

--- a/test_cases/search_coarse.json
+++ b/test_cases/search_coarse.json
@@ -47,7 +47,7 @@
         "properties": [
           {
             "name": "New York",
-            "localadmin": "Brooklyn"
+            "borough": "Brooklyn"
           }
         ]
       }


### PR DESCRIPTION
Several of our failing tests were still looking for NYC boroughs in the
localadmin field!

:warning: Note: I just enabled LGTM for this repo so I need two LGTM, :+1:, or :shipit: responses :)