### PR TITLE
Mark passing tests passing!

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -199,8 +199,8 @@
     },
     {
       "id": 7,
-      "status": "fail",
-      "description": [ "currently failing due to a double-space in the street name" ],
+      "status": "pass",
+      "description": [ "was failing due to a double-space in the street name" ],
       "issue": [ "https://github.com/pelias/openaddresses/issues/69 (comment 1)" ],
       "user": "Harish",
       "in": {

--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -358,9 +358,9 @@
     },
     {
       "id": "15",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/294",
-      "description": "cause is still unclear. see issue for future findings.",
+      "description": "there are several Hillsides, ensure the correct one comes up",
       "type": "dev",
       "in": {
         "text": "Hillside, Santa Clara",

--- a/test_cases/balance.json
+++ b/test_cases/balance.json
@@ -86,7 +86,7 @@
     },
     {
       "id": 4,
-      "status": "fail",
+      "status": "pass",
       "endpoint": "search",
       "issue": "https://github.com/pelias/api/issues/346",
       "description": [

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -70,7 +70,7 @@
     },
     {
       "id": 6,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/294",
       "description": [
         "The WOF record expected in the results has no popularity/population data,",


### PR DESCRIPTION
We've had some tests switch back to pass lately, so this updates them.
The postal code test is left with status fail because we need a new test
case.