### PR TITLE
Fix priorityThresh configuration

### DIFF
--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -23,13 +23,13 @@
       "id": "1-1",
       "status": "pass",
       "user": "Riordan",
-      "priorityThresh": 1,
       "description": ["K-stemming on Autocomplete is leading to strange results",
          "for the progressive characters in `brooklyn`, leading to jitter"],
       "in": {
         "text": "broo"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -41,13 +41,13 @@
       "id": "1-2",
       "status": "pass",
       "user": "Riordan",
-      "priorityThresh": 1,
       "description": ["K-stemming on Autocomplete is leading to strange results",
          "for the progressive characters in `brooklyn`, leading to jitter"],
       "in": {
         "text": "brook"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -59,13 +59,13 @@
       "id": "1-3",
       "status": "pass",
       "user": "Riordan",
-      "priorityThresh": 1,
       "description": ["K-stemming on Autocomplete is leading to strange results",
          "for the progressive characters in `brooklyn`, leading to jitter"],
       "in": {
         "text": "brookl"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -77,13 +77,13 @@
       "id": "1-4",
       "status": "pass",
       "user": "Riordan",
-      "priorityThresh": 1,
       "description": ["K-stemming on Autocomplete is leading to strange results",
          "for the progressive characters in `brooklyn`, leading to jitter"],
       "in": {
         "text": "brookly"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -95,13 +95,13 @@
       "id": "1-5",
       "status": "pass",
       "user": "Riordan",
-      "priorityThresh": 1,
       "description": ["K-stemming on Autocomplete is leading to strange results",
          "for the progressive characters in `brooklyn`, leading to jitter"],
       "in": {
         "text": "brooklyn"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -572,7 +572,6 @@
     {
       "id": 21,
       "user": "stephen",
-      "priorityThresh": 1,
       "notes": [
         "normally Lancaster, CA is returned first for \"Lancaster\" input while",
         "this test demonstrates that Lancaster, PA shows first when given a viewport ",
@@ -586,6 +585,7 @@
         "focus.viewport.max_lon": "-75.173684"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [{
           "name": "Lancaster",
           "region": "Pennsylvania"
@@ -595,7 +595,6 @@
     {
       "id": 22,
       "user": "stephen",
-      "priorityThresh": 1,
       "notes": [
         "normally Paris, FR is returned first for \"Paris\" input while",
         "this test demonstrates that Paris, TN shows first when given a viewport ",
@@ -609,6 +608,7 @@
         "focus.viewport.max_lon": "-82.197798"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [{
           "name": "Paris",
           "region": "Tennessee"
@@ -618,7 +618,6 @@
     {
       "id": 23,
       "user": "stephen",
-      "priorityThresh": 1,
       "notes": [
         "normally Manchester, GB is returned first for \"Manchester\" input while",
         "this test demonstrates that Manchester, NH shows first when given a viewport ",
@@ -632,6 +631,7 @@
         "focus.viewport.max_lon": "-65.323911"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [{
           "name": "Manchester",
           "region": "New Hampshire"

--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -9,11 +9,11 @@
       "description": "@nvkelso couldn't find Target in Eureka while visiting home",
       "issue": "https://github.com/pelias/pelias/issues/185",
       "user": "riordan",
-      "priorityThresh": 1,
       "in": {
         "text": "Target Eureka CA"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "layer": "venue",
@@ -30,11 +30,11 @@
       "description": "@nvkelso couldn't find Target in Eureka while visiting home",
       "issue": "https://github.com/pelias/pelias/issues/185",
       "user": "riordan",
-      "priorityThresh": 1,
       "in": {
         "text": "Target Eureka California"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "layer": "venue",
@@ -51,13 +51,13 @@
       "description": "Searching with focus on",
       "issue": "https://github.com/pelias/pelias/issues/185",
       "user": "riordan",
-      "priorityThresh": 1,
       "in": {
         "text": "Target",
         "focus.point.lat": "40.801944",
         "focus.point.lon": "-124.163611"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "layer": "venue",

--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -47,7 +47,7 @@
     },
     {
       "id": "searchpoi-3",
-      "status": "pass",
+      "status": "fail",
       "description": "Searching with focus on",
       "issue": "https://github.com/pelias/pelias/issues/185",
       "user": "riordan",


### PR DESCRIPTION
A few of our tests had `priorityThresh` set in the wrong place. It only has an effect if it's set in the `expected` section of the test case, not at the top level of the test case itself. This fixes all such cases and marks one test failing that now fails as a result.

As an aside, it feels like the `priorityThresh` setting might be more intuitive when set in the test case, not the test case's expected section. Should we modify the fuzzy-tester to support both?