### PR TITLE
Add San Francisco label centroid to SF tests

### DIFF
--- a/test_cases/san_francisco.json
+++ b/test_cases/san_francisco.json
@@ -1,10 +1,11 @@
 {
   "name": "San Francisco",
   "priorityThresh": 1,
+  "distanceThresh": 1000,
   "tests": [
     {
       "id": 1,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -16,12 +17,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": 2,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -34,12 +38,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": 3,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -52,12 +59,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": "4-autocomplete",
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "endpoint": "autocomplete",
       "in": {
@@ -70,12 +80,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": 5,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco"
@@ -86,12 +99,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": 6,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -103,12 +119,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": 7,
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -120,12 +139,15 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     },
     {
       "id": "8-autocomplete",
-      "status": "pass",
+      "status": "fail",
       "user": "Julian",
       "endpoint": "autocomplete",
       "in": {
@@ -137,6 +159,9 @@
             "region": "California",
             "name": "San Francisco"
           }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
         ]
       }
     }


### PR DESCRIPTION
Require that SF results are within 1km of the Mapshaper label centroid
of San Francisco. The Geonames centroid is a few hundred meters away,
and the math centroid of all of SF (including the Farallon islands) is
about 28km away.

Helps prevent another https://github.com/pelias/pelias/issues/356