### PR TITLE
Mark coarse reverse test failing

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -65,7 +65,10 @@
       "status": "fail",
       "endpoint": "reverse",
       "description": "Reverse does not fall back to point-in-polygon for admin areas",
-      "issue": "https://github.com/pelias/pelias/wiki/Reverse-Geocoding,-Part-Deux",
+      "issue": [
+        "https://github.com/pelias/pelias/issues/360",
+        "https://github.com/pelias/pelias/wiki/Reverse-Geocoding,-Part-Deux"
+      ],
       "in": {
         "point.lat": -40.806533324215565,
         "point.lon": 144.8101043701172

--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -62,8 +62,10 @@
     },
     {
       "id": "4",
-      "status": "pass",
+      "status": "fail",
       "endpoint": "reverse",
+      "description": "Reverse does not fall back to point-in-polygon for admin areas",
+      "issue": "https://github.com/pelias/pelias/wiki/Reverse-Geocoding,-Part-Deux",
       "in": {
         "point.lat": -40.806533324215565,
         "point.lon": 144.8101043701172


### PR DESCRIPTION
Since we [changed the max radius for reverse](https://github.com/pelias/api/pull/549),
this test has been failing. The second part of the work to improve
reverse is to fall back to point-in-polygon lookup of admin areas if
there are no venues or POIs nearby, which has yet to be done.