### PR TITLE
Change test expectation to failing due to extra space

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -199,7 +199,7 @@
     },
     {
       "id": 7,
-      "status": "pass",
+      "status": "fail",
       "description": [ "was failing due to a double-space in the street name" ],
       "issue": [ "https://github.com/pelias/openaddresses/issues/69 (comment 1)" ],
       "user": "Harish",


### PR DESCRIPTION
There is an extra space in the open addresses data. Until we improve the importer to handle extra spaces, this test is marked as failing.