### PR TITLE
Fix priority thresh for daly city

### DIFF
--- a/test_cases/autocomplete_daly_city.json
+++ b/test_cases/autocomplete_daly_city.json
@@ -2,13 +2,12 @@
   "name": "autocomplete daly city",
   "notes": "https://github.com/pelias/pelias/issues/191",
   "endpoint": "autocomplete",
-  "priorityThresh": 5,
+  "priorityThresh": 1,
   "tests": [
     {
       "id": "1",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -26,7 +25,6 @@
       "id": "2",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -44,7 +42,6 @@
       "id": "3",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -62,7 +59,6 @@
       "id": "4",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -80,7 +76,6 @@
       "id": "5",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -98,7 +93,6 @@
       "id": "6",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -116,7 +110,6 @@
       "id": "7",
       "status": "pass",
       "user": "missinglink",
-      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",

--- a/test_cases/autocomplete_daly_city.json
+++ b/test_cases/autocomplete_daly_city.json
@@ -8,12 +8,14 @@
       "id": "1",
       "status": "pass",
       "user": "missinglink",
+      "description": "for this short of an autocomplete text, it's ok for Daly City to show up a bit lower",
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
         "text": "dal"
       },
       "expected": {
+        "priorityThresh": 3,
         "properties": [
           {
             "name": "Daly City"


### PR DESCRIPTION
Similar to #246, we were incorrectly specifying a `priorityThresh` of 1 in all of these Daly City tests. The `priorityThresh` option has to be at the top level of the file, or in the `expected` block of an individual test.

In any case, what we wanted here was for all the tests in this file to have `priorityThresh` 1, which is now specified at the top of the file. It turns out the very first test, which has input text of only `dal`, doesn't pass with `priorityThresh` 1. Since it's a very short input, I changed the threshold for just that test to 3.