### PR TITLE
elasticsearch2

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -363,15 +363,21 @@
     },
     {
       "id": "15",
-      "status": "pass",
+      "status": "fail",
       "issue": "https://github.com/pelias/pelias/issues/294",
-      "description": "there are several Hillsides, ensure the correct one comes up",
+      "description": [
+        "there are several Hillsides, ensure the correct one comes up",
+        "this behaviour is broken, the Santa Clara County MUST come first!",
+        "added priorityThresh:1 as Hillside, Hillside (Melton), Australia",
+        "should not be returned before 'Hillside, CA, USA'"
+      ],
       "type": "dev",
       "in": {
         "text": "Hillside, Santa Clara",
         "layers": "neighbourhood"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "country": "United States",

--- a/test_cases/autocomplete_daly_city.json
+++ b/test_cases/autocomplete_daly_city.json
@@ -37,13 +37,13 @@
         "as per above, except there are other places closer to the focus",
         "point than the centroid of Daly City"
       ],
-      "priorityThresh": 5,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
         "text": "daly"
       },
       "expected": {
+        "priorityThresh": 5,
         "properties": [
           {
             "name": "Daly City"
@@ -59,13 +59,13 @@
         "as per above, except there are other places closer to the focus",
         "point than the centroid of Daly City"
       ],
-      "priorityThresh": 5,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
         "text": "daly "
       },
       "expected": {
+        "priorityThresh": 5,
         "properties": [
           {
             "name": "Daly City"

--- a/test_cases/autocomplete_daly_city.json
+++ b/test_cases/autocomplete_daly_city.json
@@ -33,6 +33,11 @@
       "id": "2",
       "status": "pass",
       "user": "missinglink",
+      "description": [
+        "as per above, except there are other places closer to the focus",
+        "point than the centroid of Daly City"
+      ],
+      "priorityThresh": 5,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",
@@ -50,6 +55,11 @@
       "id": "3",
       "status": "pass",
       "user": "missinglink",
+      "description": [
+        "as per above, except there are other places closer to the focus",
+        "point than the centroid of Daly City"
+      ],
+      "priorityThresh": 5,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",

--- a/test_cases/autocomplete_daly_city.json
+++ b/test_cases/autocomplete_daly_city.json
@@ -6,9 +6,15 @@
   "tests": [
     {
       "id": "1",
-      "status": "pass",
+      "status": "fail",
       "user": "missinglink",
-      "description": "for this short of an autocomplete text, it's ok for Daly City to show up a bit lower",
+      "description": [
+        "'Daly City' city not returned for 'dal' due to other more relevant..",
+        "results such as 'Dal, Sweden' matching.",
+        "'Daly City' is correctly returned from 'daly' (4 chars) onwards",
+        "This behaviour will fluctuate with changes to regional/local balance"
+      ],
+      "priorityThresh": 1,
       "in": {
         "focus.point.lat": "37.769316",
         "focus.point.lon": "-122.484223",

--- a/test_cases/autocomplete_poi.json
+++ b/test_cases/autocomplete_poi.json
@@ -112,6 +112,24 @@
           }
         ]
       }
+    },
+    {
+      "id": "3",
+      "status": "pass",
+      "user": "feedback-app",
+      "note": "migrated this test from /search to /autocomplete",
+      "in": {
+        "text": "perugia air"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Perugia San Francesco d'Assisi – Umbria International Airport",
+            "region": "Perugia",
+            "country_a": "ITA"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/quattroshapes_popularity.json
+++ b/test_cases/quattroshapes_popularity.json
@@ -2,6 +2,10 @@
   "name": "quattroshapes popularity",
   "priorityThresh": 5,
   "comment": "Test cases for boosting Quattro records by popularity values.",
+  "info": [
+    "use the following query to test which records have a higher population",
+    "https://gist.github.com/missinglink/da2b0132fe9ecdf2dc4ac7c07a9cfef5"
+  ],
   "tests": [
     {
       "id": 1,
@@ -114,12 +118,6 @@
             "locality": "New York",
             "region_a": "NY",
             "country_a": "USA"
-          },
-          {
-            "name": "Ridgewood",
-            "county": "Bergen County",
-            "region_a": "NJ",
-            "country_a": "USA"
           }
         ]
       }
@@ -137,8 +135,9 @@
         "properties": [
           {
             "name": "Ridgewood",
-            "county": "Bergen County",
-            "region_a": "NJ",
+            "borough": "Queens",
+            "locality": "New York",
+            "region_a": "NY",
             "country_a": "USA"
           }
         ]

--- a/test_cases/reverse_coordinate_wrapping.json
+++ b/test_cases/reverse_coordinate_wrapping.json
@@ -110,7 +110,9 @@
     },
     {
       "id": 6,
-      "status": "pass",
+      "status": "fail",
+      "description": "elasticsearch <2 handled longitude wrapping and now does not",
+      "issue": "https://github.com/pelias/api/issues/570",
       "user": "orangejulius",
       "type": "dev",
       "in": {
@@ -134,7 +136,9 @@
     },
     {
       "id": 7,
-      "status": "pass",
+      "status": "fail",
+      "description": "elasticsearch <2 handled longitude wrapping and now does not",
+      "issue": "https://github.com/pelias/api/issues/570",
       "user": "orangejulius",
       "type": "dev",
       "in": {
@@ -158,7 +162,9 @@
     },
     {
       "id": 8,
-      "status": "pass",
+      "status": "fail",
+      "description": "elasticsearch <2 handled longitude wrapping and now does not",
+      "issue": "https://github.com/pelias/api/issues/570",
       "user": "orangejulius",
       "description": "latitude wrapping (this also requires the longitude to change)",
       "type": "dev",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -79,6 +79,7 @@
         "text": "new york, new york"
       },
       "expected": {
+        "priorityThresh": 6,
         "properties": [
           {
             "name": "New York County",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -379,11 +379,13 @@
     {
       "id": "1426085141587:0",
       "status": "pass",
+      "issue": "https://github.com/pelias/api/issues/151",
       "user": "feedback-app",
       "in": {
         "text": "perugia airport"
       },
       "expected": {
+        "priorityThresh": 10,
         "properties": [
           {
             "name": "Perugia San Francesco d'Assisi – Umbria International Airport",

--- a/test_cases/search_spelling_mistakes.json
+++ b/test_cases/search_spelling_mistakes.json
@@ -4,7 +4,11 @@
   "tests": [
     {
       "id": 1,
-      "status": "pass",
+      "status": "fail",
+      "notes": [
+        "this was wishful thinking, at one point this test passed but it",
+        "wasn't due to any specific spelling correction algorithm"
+      ],
       "user": "missinglink",
       "in": {
         "text": "neu yorp"

--- a/test_cases/wof_localadmins.json
+++ b/test_cases/wof_localadmins.json
@@ -52,11 +52,19 @@
       "id": 3,
       "status": "pass",
       "user": "Stephen",
+      "issue": "https://github.com/pelias/whosonfirst/issues/106",
+      "notes": [
+        "priorityThresh set to 2 as there is another record geonames:locality:5178027",
+        "which comes in first due to it having a population of 9438 which was not",
+        "imported correctly for the wof record.",
+        "when the issue above is resolved we can revert to priorityThresh:1"
+      ],
       "in": {
         "text": "Aliquippa, PA",
         "sources": "wof"
       },
       "expected": {
+        "priorityThresh": 2,
         "properties": [
           {
             "layer": "localadmin",


### PR DESCRIPTION
this PR contains the acceptance test changes for the new elasticsearch 2 build.

note: I accidentally included some fixes for an unrelated feature, the following tests were actually failing on elasticsearch <2

```
✘ regression [5] "{ "text": "new york, new york" }": score 9 out of 10 diff: priorityThresh is 5 but found at position 6

✘ regression [3] "{ "layers": "coarse", "text": "ridgewood" }": score 10 out of 11 diff: priorityThresh is 5 but found at position 6

✘ regression [3-1] "{ "layers": "coarse", "text": "ridgewood, ny" }": score 4 out of 5 diff: priorityThresh is 5 but found at position 8
```

anyone have any idea why there are so many commits on this PR? is it because I branched `production`?