### PR TITLE
Mark improvements passing

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -195,7 +195,7 @@
     },
     {
       "id": 7,
-      "status": "fail",
+      "status": "pass",
       "description": [ "was failing due to a double-space in the street name" ],
       "issue": [ "https://github.com/pelias/openaddresses/issues/69 (comment 1)" ],
       "user": "Harish",

--- a/test_cases/reverse_coordinate_wrapping.json
+++ b/test_cases/reverse_coordinate_wrapping.json
@@ -6,7 +6,7 @@
   "tests": [
     {
       "id": 3,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/wof-pip-service/issues/40",
       "description": "base case (no wrapping) for a reverse query in NYC",
       "user": "sev",

--- a/test_cases/san_francisco.json
+++ b/test_cases/san_francisco.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "id": 1,
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -25,7 +25,7 @@
     },
     {
       "id": 2,
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -46,7 +46,7 @@
     },
     {
       "id": 3,
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -67,7 +67,7 @@
     },
     {
       "id": "4-autocomplete",
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "endpoint": "autocomplete",
       "in": {
@@ -88,7 +88,7 @@
     },
     {
       "id": 5,
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "in": {
         "text": "san francisco"
@@ -107,7 +107,7 @@
     },
     {
       "id": 6,
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -127,7 +127,7 @@
     },
     {
       "id": 7,
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "in": {
         "text": "san francisco",
@@ -147,7 +147,7 @@
     },
     {
       "id": "8-autocomplete",
-      "status": "fail",
+      "status": "pass",
       "user": "Julian",
       "endpoint": "autocomplete",
       "in": {

--- a/test_cases/search_coarse.json
+++ b/test_cases/search_coarse.json
@@ -23,7 +23,7 @@
     },
     {
       "id": 2,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/295",
       "description": "data issue",
       "user": "Diana",


### PR DESCRIPTION
Tests that were failing due to an incorrect San Francisco centroid, extra whitespace, and the neighbourhood filtering issue are now all passing!