### PR TITLE
Add autocomplete test for "San Francisco" with focus in NYC

### DIFF
--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -239,6 +239,32 @@
           [ -73.93827, 40.663931 ]
         ]
       }
+    },
+    {
+      "id": 29,
+      "status": "fail",
+      "user": "julian",
+      "notes": [
+        "searching for San Francisco via autocomplete with a focus in NYC"
+      ],
+      "issue": "https://github.com/pelias/pelias/issues/330",
+      "in": {
+        "focus.point.lat": 40.744131,
+        "focus.point.lon": -73.990424,
+        "text": "San Francisco"
+      },
+      "expected": {
+        "properties": [
+          {
+            "region": "California",
+            "name": "San Francisco",
+            "layer": "locality"
+          }
+        ],
+        "coordinates": [
+          [ -122.431272, 37.778008 ]
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
I realized we did not have an acceptance test for this case, even though
we had other similar ones such as https://github.com/pelias/acceptance-tests/pull/232.

Connects https://github.com/pelias/acceptance-tests/issues/243
Connects https://github.com/pelias/pelias/issues/330