### PR TITLE
Correct locality and region in test

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -504,8 +504,8 @@
             "housenumber": "1",
             "street": "Hämeenkatu",
             "name": "Hämeenkatu 1",
-            "locality": "Turku",
-            "region": "Southwest Finland",
+            "locality": "Tampere",
+            "region": "Pirkanmaa",
             "macroregion": "Lansi ja Sisa-Suomi",
             "country": "Finland",
             "country_a": "FIN"


### PR DESCRIPTION
Somehow this was messed up in the [pull request that created this test](https://github.com/pelias/acceptance-tests/pull/217). The expected
locality didn't match the input string!

Note: this test has been updated with the new region name from `prod_build`, so it won't pass on prod yet.
