### PR TITLE
Fix autocomplete boundary.country test

### DIFF
--- a/test_cases/autocomplete_boundary_country.json
+++ b/test_cases/autocomplete_boundary_country.json
@@ -1,7 +1,8 @@
 
 {
   "name": "autocomplete boundary.country",
-  "priorityThresh": 5,
+  "priorityThresh": 10,
+  "description": "London does not appear very high in the results, which is unfortunate, but for testing boundary.country is ok if we set priorityThresh to 10",
   "endpoint": "autocomplete",
   "tests": [
     {


### PR DESCRIPTION
The autocomplete results for this query aren't perfect, but the main
thing we care about for the purposes of this test is the
boundary.country functionality. Setting priorityThresh to 10 makes
things ok.