### PR TITLE
Add test for fallback size anomaly

### DIFF
--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -588,7 +588,10 @@
       "id": 25,
       "status": "pass",
       "user": "trescube",
-      "notes": [],
+      "notes": [
+        "test ES query size hardcoding to lower score address matches are returned",
+        "https://github.com/pelias/pelias/issues/434"
+      ],
       "in": {
         "text": "82 Whitney Ave, Hamilton, Ontario",
         "size": 1

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -583,6 +583,26 @@
           }
         ]
       }
+    },
+    {
+      "id": 25,
+      "status": "pass",
+      "user": "trescube",
+      "notes": [],
+      "in": {
+        "text": "82 Whitney Ave, Hamilton, Ontario",
+        "size": 1
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": {
+          "layer": "address",
+          "housenumber": "82",
+          "street": "Whitney Avenue",
+          "locality": "Hamilton",
+          "region": "Ontario"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This test exercises the behavior where `size=1` was supplied along with an input containing an address that happened to score lower than a fallback query.  