### PR TITLE
Fix name of search street fallback test suite

### DIFF
--- a/test_cases/search_street_fallback.json
+++ b/test_cases/search_street_fallback.json
@@ -1,5 +1,5 @@
 {
-  "name": "autocomplete street fallback",
+  "name": "search street fallback",
   "priorityThresh": 5,
   "endpoint": "search",
   "description": [


### PR DESCRIPTION
Looks to have just been a little copy paste error.