### PR TITLE
Make street tests pass

### DIFF
--- a/test_cases/search_street_fallback.json
+++ b/test_cases/search_street_fallback.json
@@ -22,10 +22,6 @@
             "country_a": "DEU",
             "street": "Grolmanstraße",
             "layer": "street"
-          },{
-            "country_a": "DEU",
-            "street": "Grolmanstraße",
-            "layer": "address"
           }
         ]
       }
@@ -43,10 +39,6 @@
             "country_a": "NZL",
             "street": "Glen Road",
             "layer": "street"
-          },{
-            "country_a": "NZL",
-            "street": "Glen Road",
-            "layer": "address"
           }
         ]
       }

--- a/test_cases/search_street_fallback.json
+++ b/test_cases/search_street_fallback.json
@@ -13,7 +13,7 @@
       "user": "missinglink",
       "issue": "https://github.com/pelias/openstreetmap/issues/28",
       "in": {
-        "text": "grolmanstraße, berlin"
+        "text": "grolmanstraße, berlin, germany"
       },
       "expected": {
         "coordinates": [ 13.324042, 52.503915 ],


### PR DESCRIPTION
These were failing due to two things unrelated to the intent of these tests.

1.) https://github.com/pelias/pelias/issues/442, which will be tested separately
2.) Updates to our text analysis via libpostal that now allow us to return only streets (no addresses) when there is no housenumber in the query :tada: :balloon: 