### PR TITLE
Allow encoding test results to come from any source

### DIFF
--- a/test_cases/encoding.json
+++ b/test_cases/encoding.json
@@ -13,7 +13,6 @@
       "expected": {
         "properties": [
           {
-            "source": "geonames",
             "county": "Cuauhtémoc",
             "region": "Ciudad de México",
             "name": "Mexico City",
@@ -33,7 +32,6 @@
       "expected": {
         "properties": [
           {
-            "source": "geonames",
             "name": "Pärnu",
             "region": "Pärnumaa",
             "locality": "Pärnu",
@@ -61,7 +59,6 @@
       "expected": {
         "properties": [
           {
-            "source": "geonames",
             "name": "Chambéry",
             "macroregion": "Rhône-Alpes",
             "locality": "Chambéry",
@@ -83,7 +80,6 @@
       "expected": {
         "properties": [
           {
-            "source": "geonames",
             "name": "Chambéry",
             "macroregion": "Rhône-Alpes",
             "locality": "Chambéry",


### PR DESCRIPTION
After https://github.com/pelias/api/pull/687 the API will prefer to
return WOF records if they are found to be a duplicate of a Geonames
record.