### PR TITLE
Add test for autocomplete with boundary.rect

### DIFF
--- a/test_cases/autocomplete_boundary_rect.json
+++ b/test_cases/autocomplete_boundary_rect.json
@@ -1,0 +1,33 @@
+{
+  "name": "autocomplete boundary.rect",
+  "priorityThresh": 3,
+  "endpoint": "autocomplete",
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "Julian",
+      "type": "dev",
+      "in": {
+        "boundary.rect.min_lat":19,
+        "boundary.rect.max_lat":20,
+        "boundary.rect.min_lon":-99,
+        "boundary.rect.max_lon":-98,
+        "text": "san francisco"
+      },
+      "expected": {
+        "properties": [
+          {
+              "name": "San Francisco",
+              "country_a": "MEX"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [{
+          "country_a": "USA"
+        }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a search for San Francisco, with a bounding box that covers part
of Mexico (that contains a San Francisco). It checks that the results
have Mexico as the country, but not USA.

Connects https://github.com/pelias/api/pull/703