### PR TITLE
added iso2->iso3 country code conversion to /search endpoint

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -318,6 +318,54 @@
           }
         ]
       }
+    },
+    {
+      "id": 12,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "notes": [
+        "this test verifies that an iso2 country matches"
+      ],
+      "in": {
+        "text": "30 West 26th Street, New York, NY, US"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "USA",
+            "region": "New York",
+            "region_a": "NY",
+            "locality": "New York",
+            "housenumber": "30",
+            "street": "West 26th Street"
+          }
+        ]
+      }
+    },
+    {
+      "id": 13,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "notes": [
+        "this test verifies that an iso2 country matches"
+      ],
+      "in": {
+        "text": "grolmanstraße 51, berlin, de"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "DEU",
+            "locality": "Berlin",
+            "housenumber": "51",
+            "street": "Grolmanstraße"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -318,54 +318,6 @@
           }
         ]
       }
-    },
-    {
-      "id": 12,
-      "status": "pass",
-      "user": "trescube",
-      "type": "dev",
-      "notes": [
-        "this test verifies that an iso2 country matches"
-      ],
-      "in": {
-        "text": "30 West 26th Street, New York, NY, US"
-      },
-      "expected": {
-        "properties": [
-          {
-            "layer": "address",
-            "country_a": "USA",
-            "region": "New York",
-            "region_a": "NY",
-            "locality": "New York",
-            "housenumber": "30",
-            "street": "West 26th Street"
-          }
-        ]
-      }
-    },
-    {
-      "id": 13,
-      "status": "pass",
-      "user": "trescube",
-      "type": "dev",
-      "notes": [
-        "this test verifies that an iso2 country matches"
-      ],
-      "in": {
-        "text": "grolmanstraße 51, berlin, de"
-      },
-      "expected": {
-        "properties": [
-          {
-            "layer": "address",
-            "country_a": "DEU",
-            "locality": "Berlin",
-            "housenumber": "51",
-            "street": "Grolmanstraße"
-          }
-        ]
-      }
     }
   ]
 }

--- a/test_cases/search_iso2_to_iso3.json
+++ b/test_cases/search_iso2_to_iso3.json
@@ -1,0 +1,110 @@
+{
+  "name": "ISO2->ISO3 internal conversion",
+  "notes": "this test verifies that an iso2 country matches",
+  "priorityThresh": 1,
+  "endpoint": "search",
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "in": {
+        "text": "30 West 26th Street, New York, NY, US"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "USA",
+            "region": "New York",
+            "region_a": "NY",
+            "locality": "New York",
+            "street": "West 26th Street",
+            "housenumber": "30"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "in": {
+        "text": "grolmanstraße 51, berlin, de"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "DEU",
+            "locality": "Berlin",
+            "street": "Grolmanstraße",
+            "housenumber": "51"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "in": {
+        "text": "24 Rue de Sèvres, 75007 Paris, Fr"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "FRA",
+            "locality": "Paris",
+            "street": "Rue de Sèvres",
+            "housenumber": "24"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "in": {
+        "text": "22 Lloyd George Ave, Toronto Ontario CA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "CAN",
+            "locality": "Toronto",
+            "street": "Lloyd George Ave",
+            "housenumber": "22"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "in": {
+        "text": "327 Rincon de Romos, Aguascalientes, MX"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "MEX",
+            "locality": "Aguascalientes",
+            "street": "Rincón De Romos",
+            "housenumber": "327"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
These tests verify that an ISO2 country code identified by libpostal can be matched (currently manually converted but should carry on once Pelias supports ISO2 in data as an altname).