### PR TITLE
marked diacritical tests passing now

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -494,7 +494,7 @@
     },
     {
       "id": "20",
-      "status": "fail",
+      "status": "pass",
       "in": {
         "text": "1 Hämeenkatu, Tampere, Finland"
       },

--- a/test_cases/component_geocoding.json
+++ b/test_cases/component_geocoding.json
@@ -702,6 +702,30 @@
         ]
       }
     },
+    {
+      "id": 703,
+      "status": "pass",
+      "user": "Stephen",
+      "description": "",
+      "notes": "similar to wof_regions/#8 but uses component geocoding to show that region works",
+      "in": {
+        "region": "Xaçmaz",
+        "country": "Azerbaijan",
+        "sources": "wof"
+      },
+      "expected": {
+        "priorityThresh": 2,
+        "properties": [
+          {
+            "layer": "region",
+            "name": "Xaçmaz",
+            "region": "Xaçmaz",
+            "country": "Azerbaijan",
+            "country_a": "AZE"
+          }
+        ]
+      }
+    },
 
     {
       "id": 800,

--- a/test_cases/encoding.json
+++ b/test_cases/encoding.json
@@ -23,7 +23,7 @@
     },
     {
       "id": 2,
-      "status": "fail",
+      "status": "pass",
       "endpoint": "search",
       "description": "make sure that results return the appropriate accents on results",
       "notes": "https://github.com/pelias/api/issues/731",
@@ -44,7 +44,7 @@
     },
     {
       "id": 3,
-      "status": "fail",
+      "status": "pass",
       "endpoint": "search",
       "issue": [
         "https://github.com/pelias/api/issues/600",
@@ -64,27 +64,6 @@
             "macroregion": "Rhône-Alpes",
             "locality": "Chambéry",
             "label": "Chambéry, France",
-            "country": "France"
-          }
-        ]
-      }
-    },
-    {
-      "id": 4,
-      "status": "fail",
-      "endpoint": "search",
-      "description": "the Chambéry accent issue, with the accented e represented as 2 characters",
-      "issue": "https://github.com/pelias/api/issues/600",
-      "in":{
-        "text": "Chambéry"
-      },
-      "expected": {
-        "properties": [
-          {
-            "name": "Chambéry",
-            "macroregion": "Rhône-Alpes",
-            "locality": "Chambéry",
-            "label": "Chambéry, France",
             "country": "France"
           }
         ]

--- a/test_cases/wof_regions.json
+++ b/test_cases/wof_regions.json
@@ -155,11 +155,12 @@
     },
     {
       "id": 8,
-      "status": "pass",
+      "status": "fail",
       "user": "Stephen",
       "description": "",
+      "notes": "libpostal identifies this as a city/country even though it's a WOF region",
       "in": {
-        "text": "Xaçmaz, AZ",
+        "text": "Xaçmaz, Azerbaijan",
         "sources": "wof"
       },
       "expected": {


### PR DESCRIPTION
moved wof_region#8 test to component_geocoding to show that it still works as a region despite libpostal parsing as a city/country.  

See pelias/text-analyzer#18