### PR TITLE
Libpostal parses address in component

### DIFF
--- a/test_cases/component_geocoding.json
+++ b/test_cases/component_geocoding.json
@@ -62,7 +62,7 @@
     },
     {
       "id": 3,
-      "status": "fail",
+      "status": "pass",
       "user": "trescube",
       "type": "dev",
       "notes": [

--- a/test_cases/component_geocoding.json
+++ b/test_cases/component_geocoding.json
@@ -18,7 +18,7 @@
         "properties": [
           {
             "layer": "address",
-            "name": "1090 N Charlotte Street",
+            "name": "1090 N Charlotte St",
             "country_a": "USA",
             "country": "United States",
             "region": "Pennsylvania",
@@ -26,8 +26,8 @@
             "county": "Lancaster County",
             "locality": "Lancaster",
             "housenumber": "1090",
-            "street": "N Charlotte Street",
-            "label": "1090 N Charlotte Street, Lancaster, PA, USA"
+            "street": "N Charlotte St",
+            "label": "1090 N Charlotte St, Lancaster, PA, USA"
           }
         ]
       }

--- a/test_cases/component_geocoding.json
+++ b/test_cases/component_geocoding.json
@@ -118,7 +118,81 @@
         ]
       }
     },
-
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "notes": "libpostal parses as postcode/road",
+      "in": {
+        "address": "1338 Kobbe Ave",
+        "locality": "San Francisco",
+        "region": "CA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "name": "1338 Kobbe Ave",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "California",
+            "region_a": "CA",
+            "locality": "San Francisco",
+            "label": "1338 Kobbe Ave, San Francisco, CA, USA"
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "notes": "libpostal parses as house_number/road, non-US address",
+      "in": {
+        "address": "Grolmanstrasse 51",
+        "locality": "Berlin"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "name": "Grolmanstraße 51",
+            "country_a": "DEU",
+            "country": "Germany",
+            "locality": "Berlin",
+            "label": "Grolmanstraße 51, Berlin, Germany"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "user": "trescube",
+      "type": "dev",
+      "notes": "libpostal parses as house_number/suburb/road, non-US address",
+      "in": {
+        "address": "5 russian hill pl",
+        "locality": "San Francisco",
+        "region": "CA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "name": "5 Russian Hill Pl",
+            "country_a": "USA",
+            "country": "United States",
+            "region": "California",
+            "region_a": "CA",
+            "locality": "San Francisco",
+            "label": "5 Russian Hill Pl, San Francisco, CA, USA"
+          }
+        ]
+      }
+    },
 
     {
       "id": 100,


### PR DESCRIPTION
Exercises the ways that the API interprets the results of libpostal. 

See pelias/api#736