### PR TITLE
Replace deprecated record in structured tests

### DIFF
--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -639,19 +639,19 @@
       "type": "dev",
       "notes": "unambiguous county",
       "in": {
-        "county": "重庆市",
+        "county": "Chongqing",
         "country": "China"
       },
       "expected": {
         "properties": [
           {
             "layer": "county",
-            "name": "重庆市",
+            "name": "Chongqing",
             "country_a": "CHN",
             "country": "China",
             "region": "Chongqing",
-            "county": "重庆市",
-            "label": "重庆市, China"
+            "county": "Chongqing",
+            "label": "Chongqing, China"
           }
         ]
       }


### PR DESCRIPTION
As mentioned in https://github.com/whosonfirst-data/whosonfirst-data/issues/570,
the record for Chongqing has been deprecated and a new one created. This
new one has a different default name, so the test has to change.