### PR TITLE
Change fallback query address to a large value

### DIFF
--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -70,7 +70,7 @@
           "https://github.com/pelias/pelias/issues/454"
       ],
       "in": {
-        "address": "1220 Calle de Lago",
+        "address": "12200000 Calle de Lago",
         "locality": "Socorro",
         "region": "NM"
       },


### PR DESCRIPTION
This ensures that the address can't possibly correspond to a valid
location on the street, and the interpolation service will not return
any results.