### PR TITLE
Add test cases for Washington, D.C.

### DIFF
--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -366,6 +366,23 @@
           }
         ]
       }
+    },
+    {
+      "id": 24,
+      "status": "fail",
+      "description": "Washington, D.C. venues should have District of Columbia abbreviation",
+      "issue": "https://github.com/pelias/labels/issues/14",
+      "user": "julian",
+      "in": {
+        "text": "national air and space museum, washington dc"
+      },
+      "expected": {
+        "properties": [
+          {
+            "label": "National Air and Space Museum, Washington, D.C., USA"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/washington_dc.json
+++ b/test_cases/washington_dc.json
@@ -1,0 +1,89 @@
+{
+  "name": "washington dc",
+  "priorityThresh": 1,
+  "tests": [
+    {
+      "id": 1,
+      "status": "fail",
+      "user": "julian",
+      "description": "address searches in washington DC should work when 'district of columbia' is abbreviated",
+      "issue": "https://github.com/pelias/pelias/issues/509",
+      "in": {
+        "text": "1705 P St NW, Washington, dc"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "1705",
+            "street": "P Street Nw",
+            "locality": "Washington",
+            "region": "District of Columbia"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "julian",
+      "description": "address searches in washington DC should work when 'district of columbia' is not abbreviated",
+      "issue": "https://github.com/pelias/pelias/issues/509",
+      "in": {
+        "text": "1705 P St NW, Washington, district of columbia"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "1705",
+            "street": "P Street Nw",
+            "locality": "Washington",
+            "region": "District of Columbia"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "julian",
+      "description": "venue searches in washington DC should work when 'district of columbia' is abbreviated",
+      "issue": "https://github.com/pelias/pelias/issues/509",
+      "in": {
+        "text": "busboys and poets, washington dc"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "venue",
+            "name": "Busboys and Poets",
+            "locality": "Washington",
+            "region": "District of Columbia"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "julian",
+      "description": "S Street in Washington, DC should not be interpreted as 'South St'",
+      "issue": "https://github.com/pelias/pelias/issues/329",
+      "in": {
+        "text": "641 S Street NW, washington, district of columbia"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "housenumber": "641",
+            "street": "S Street Nw",
+            "locality": "Washington",
+            "region": "District of Columbia"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds test cases for Washington, D.C. addresses and venues. It includes tests for proper label generation, ability to search when abbreviating "District of Columbia", and the possibility of incorrectly displaying "S Street" as "South Street".

The test cases are taken from these issues:
https://github.com/pelias/pelias/issues/509
https://github.com/pelias/labels/issues/14
https://github.com/pelias/pelias/issues/329