### PR TITLE
Set API key for running acceptance tests on Travis correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 before_script:
     - npm prune
-    - 'echo "{ \"mapzen\": { \"api_key\": { \"pelias.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
+    - 'echo "{ \"mapzen\": { \"api_key\": { \"search.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
 node_js:
   - 6
 sudo: false

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "mapzen",
   "main": "index.js",
   "scripts": {
+    "config": "node -e \"console.log(JSON.stringify(require( 'pelias-config' ).generate(), null, 2))\"",
     "test": "./node_modules/pelias-fuzzy-tester/bin/fuzzy-tester",
     "lint": "jshint .",
     "validate": "npm ls"


### PR DESCRIPTION
Our acceptance tests were failing because they were running slowly, and they were running slowly because the API key configuration that's shoehorned into travis was setting the key for the wrong domain.

This PR fixes the domain and also adds a helpful config script inspired by @trescube. It was used to help make sure things were set up correctly, so I kept it around.