### PR TITLE
Update acceptance tests

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -249,7 +249,9 @@
     },
     {
       "id": 9,
-      "status": "pass",
+      "status": "fail",
+      "description": "The mission is now a macrohood, so we won't be able to get this right until that's imported",
+      "issue": "https://github.com/pelias/whosonfirst/issues/213",
       "user": "Harish",
       "in": {
         "text": "3010 20th St San Francisco CA 94110"
@@ -264,7 +266,7 @@
             "region_a": "CA",
             "county": "San Francisco County",
             "locality": "San Francisco",
-            "neighbourhood": "Mission District",
+            "macrohood": "Mission District",
             "postalcode": "94110",
             "housenumber": "3010",
             "street": "20th Street",

--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -138,7 +138,9 @@
     },
     {
       "id": "7",
-      "status": "pass",
+      "status": "fail",
+      "description": "the mission is now a macrohood, which we don't yet import",
+      "issue": "https://github.com/pelias/whosonfirst/issues/213",
       "type": "dev",
       "in": {
         "text": "mission, san francisco",
@@ -148,7 +150,7 @@
         "properties": [
           {
             "name": "Mission District",
-            "layer": "neighbourhood",
+            "layer": "macrohood",
             "country_a": "USA",
             "country": "United States",
             "region": "California",

--- a/test_cases/autocomplete_street_centroids.json
+++ b/test_cases/autocomplete_street_centroids.json
@@ -59,8 +59,9 @@
       }
     },{
       "id": 3,
-      "status": "pass",
+      "status": "fail",
       "user": "missinglink",
+      "issue": "https://github.com/pelias/pelias/issues/545",
       "in": {
         "sources": "osm",
         "layers": "street",

--- a/test_cases/geonames.json
+++ b/test_cases/geonames.json
@@ -5,9 +5,10 @@
   "tests": [
     {
       "id": "1",
-      "status": "pass",
+      "status": "fail",
       "user": "diana",
       "description": "geonames ids in admin hierarchy must not be misrepresented as wof ids",
+      "issue": "https://github.com/pelias/pelias/issues/539",
       "in": {
         "size": 1,
         "sources": "geonames",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -360,7 +360,9 @@
     },
     {
       "id": 11,
-      "status": "pass",
+      "status": "fail",
+      "description": "SoHo was accidentally renamed Soho, should be fixed soon",
+      "issue": "https://github.com/whosonfirst-data/whosonfirst-data/issues/744",
       "type": "dev",
       "user": "hkrishna",
       "in": {

--- a/test_cases/search_street_centroids.json
+++ b/test_cases/search_street_centroids.json
@@ -59,8 +59,9 @@
       }
     },{
       "id": 3,
-      "status": "pass",
+      "status": "fail",
       "user": "missinglink",
+      "issue": "https://github.com/pelias/pelias/issues/545",
       "in": {
         "sources": "osm",
         "layers": "street",

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -333,13 +333,15 @@
       "status": "pass",
       "user": "trescube",
       "type": "dev",
-      "notes": "borough",
+      "notes": "tests borough. priorityThresh can be removed when geonames records are deduped properly or removed",
+      "issue": "ttps://github.com/pelias/pelias/issues/322",
       "in": {
         "borough": "Manhattan",
         "locality": "New York",
         "region": "NY"
       },
       "expected": {
+        "priorityThresh": 2,
         "properties": [
           {
             "layer": "borough",

--- a/test_cases/wof_neighbourhoods.json
+++ b/test_cases/wof_neighbourhoods.json
@@ -7,14 +7,14 @@
       "status": "pass",
       "user": "Stephen",
       "in": {
-        "text": "Weeksville, Brooklyn, New York",
+        "text": "Crown Heights, Brooklyn, New York",
         "sources": "wof"
       },
       "expected": {
         "properties": [
           {
             "layer": "neighbourhood",
-            "name": "Weeksville",
+            "name": "Crown Heights",
             "locality": "New York",
             "borough": "Brooklyn",
             "county": "Kings County",


### PR DESCRIPTION
Lots has changed in acceptance test land.

Some highlights:

* Weeksville is now a microhood, not a neighbourhood
* The Mission is now a macrohood, not a neighbourhood
* W 26th St has split in two
* SoHo was accidentally renamed Soho