### PR TITLE
Update expectations for autocomplete boundary.country test

### DIFF
--- a/test_cases/autocomplete_boundary_country.json
+++ b/test_cases/autocomplete_boundary_country.json
@@ -1,8 +1,8 @@
 
 {
   "name": "autocomplete boundary.country",
-  "priorityThresh": 10,
-  "description": "London does not appear very high in the results, which is unfortunate, but for testing boundary.country is ok if we set priorityThresh to 10",
+  "priorityThresh": 1,
+  "description": "ensure that only USA results, and especially not GBR results, come back with boundary.country set",
   "endpoint": "autocomplete",
   "tests": [
     {
@@ -24,7 +24,7 @@
       "expected": {
         "properties": [
           {
-            "name": "London"
+            "country_a": "USA"
           }
         ]
       }


### PR DESCRIPTION
This test doesn't actually care that London in particular shows up, but
is meant to ensure that results in the specified `boundary.country` are
the only ones that appear.