### PR TITLE
Update expectations for Brooklyn test without additional geo-context

### DIFF
--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -29,7 +29,7 @@
         "text": "broo"
       },
       "expected": {
-        "priorityThresh": 1,
+        "priorityThresh": 5,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -47,7 +47,7 @@
         "text": "brook"
       },
       "expected": {
-        "priorityThresh": 1,
+        "priorityThresh": 5,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -65,7 +65,7 @@
         "text": "brookl"
       },
       "expected": {
-        "priorityThresh": 1,
+        "priorityThresh": 5,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -83,7 +83,7 @@
         "text": "brookly"
       },
       "expected": {
-        "priorityThresh": 1,
+        "priorityThresh": 5,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"
@@ -101,7 +101,7 @@
         "text": "brooklyn"
       },
       "expected": {
-        "priorityThresh": 1,
+        "priorityThresh": 5,
         "properties": [
           {
             "label": "Brooklyn, New York, NY, USA"

--- a/test_cases/brooklyn.json
+++ b/test_cases/brooklyn.json
@@ -67,6 +67,7 @@
         "text": "brooklyn"
       },
       "expected": {
+        "priorityThresh": 5,
         "properties": [
           {
             "name": "Brooklyn",
@@ -103,6 +104,7 @@
         "text": "brooklyn"
       },
       "expected": {
+        "priorityThresh": 5,
         "properties": [
           {
             "name": "Brooklyn",

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -360,7 +360,7 @@
     },
     {
       "id": 11,
-      "status": "fail",
+      "status": "pass",
       "description": "SoHo was accidentally renamed Soho, should be fixed soon",
       "issue": "https://github.com/whosonfirst-data/whosonfirst-data/issues/744",
       "type": "dev",


### PR DESCRIPTION
It's unfair to expect Brooklyn NY to show up first in the results when the query just has `brooklyn` or `broo` and no other geographical information is given.