### PR TITLE
added tests for coarse fallback and non-coarse first pass

### DIFF
--- a/test_cases/reverse_address.json
+++ b/test_cases/reverse_address.json
@@ -1,0 +1,166 @@
+{
+  "name": "reverse non-coarse",
+  "priorityThresh": 1,
+  "endpoint": "reverse",
+  "tests": [
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "trescube",
+      "description": "there should be no non-address results, lat/lon is for Lancaster, PA",
+      "type": "dev",
+      "in": {
+        "point.lat": 40.038123,
+        "point.lon": -76.304096
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "layer": "locality"
+          },
+          {
+            "layer": "localadmin"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "trescube",
+      "description": "there should be no non-address results, lat/lon is for Ventura County, CA",
+      "type": "dev",
+      "in": {
+        "point.lat": 34.35755,
+        "point.lon": -119.126008
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "street"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "layer": "county"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "trescube",
+      "description": "addresses should be returned before coarse results, this lat/lon is for Red Lion, PA",
+      "type": "dev",
+      "in": {
+        "point.lat": 39.898111,
+        "point.lon": -76.607958
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:locality:101717221"
+          },
+          {
+            "gid": "whosonfirst:localadmin:404487867"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "trescube",
+      "description": "venues should be returned before coarse results, this lat/lon is for Red Lion, PA",
+      "type": "dev",
+      "in": {
+        "point.lat": 39.898111,
+        "point.lon": -76.607958,
+        "layers": "venue,locality"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "venue"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:locality:101717221"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "trescube",
+      "description": "addresses should be returned before coarse results, this lat/lon is for Red Lion, PA",
+      "type": "dev",
+      "in": {
+        "point.lat": 39.898111,
+        "point.lon": -76.607958,
+        "layers": "address,locality"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:locality:101717221"
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "user": "trescube",
+      "description": "streets should be returned before coarse results, this lat/lon is for Red Lion, PA",
+      "type": "dev",
+      "in": {
+        "point.lat": 39.898111,
+        "point.lon": -76.607958,
+        "layers": "street,locality"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "street"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:locality:101717221"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test_cases/reverse_address.json
+++ b/test_cases/reverse_address.json
@@ -76,10 +76,7 @@
       "unexpected": {
         "properties": [
           {
-            "gid": "whosonfirst:locality:101717221"
-          },
-          {
-            "gid": "whosonfirst:localadmin:404487867"
+            "layer": "locality"
           }
         ]
       }
@@ -105,7 +102,7 @@
       "unexpected": {
         "properties": [
           {
-            "gid": "whosonfirst:locality:101717221"
+            "layer": "locality"
           }
         ]
       }
@@ -131,7 +128,7 @@
       "unexpected": {
         "properties": [
           {
-            "gid": "whosonfirst:locality:101717221"
+            "layer": "locality"
           }
         ]
       }
@@ -157,7 +154,7 @@
       "unexpected": {
         "properties": [
           {
-            "gid": "whosonfirst:locality:101717221"
+            "layer": "locality"
           }
         ]
       }

--- a/test_cases/reverse_coarse.json
+++ b/test_cases/reverse_coarse.json
@@ -347,7 +347,63 @@
           }
         ]
       }
+    },
+    {
+      "id": 20,
+      "status": "pass",
+      "user": "trescube",
+      "description": "address/venue/street not found should fallback to coarse reverse (no layers specified)",
+      "type": "dev",
+      "in": {
+        "point.lat": 34.119423,
+        "point.lon": -106.284351
+      },
+      "expected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:county:102081575",
+            "name": "Socorro County"
+          }
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "status": "pass",
+      "user": "trescube",
+      "description": "address/venue/street not found should fallback to coarse reverse (no layers specified)",
+      "type": "dev",
+      "in": {
+        "point.lat": 57.672717,
+        "point.lon": 36.002802
+      },
+      "expected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:county:1108735021",
+            "name": "Maksatikhinskij"
+          }
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "status": "pass",
+      "user": "trescube",
+      "description": "https://github.com/pelias/pelias/issues/585, should fallback to coarse",
+      "type": "dev",
+      "in": {
+        "point.lat": 38.260674,
+        "point.lon": -8.5448
+      },
+      "expected": {
+        "properties": [
+          {
+            "gid": "whosonfirst:region:85687359",
+            "name": "Setúbal"
+          }
+        ]
+      }
     }
-
   ]
 }


### PR DESCRIPTION
These test cover:
- fallback to coarse reverse (PiP) when there are no non-coarse results
- only request non-coarse from ES regardless of `layers` parameter