### PR TITLE
Addresses for AUS, BRA, CAN, DEU, ESP, FRA, GRB, MEX, RUS, ITA

### DIFF
--- a/test_cases/international.json
+++ b/test_cases/international.json
@@ -1,0 +1,370 @@
+{
+  "name": "International addresses",
+  "priorityThresh": 5,
+  "normalizers": {
+    "name": [
+      "toUpperCase"
+    ]
+  },
+  "tests": [
+    {
+      "id": 0,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "553 St. Kilda Road Melbourne 3004",
+        "boundary.country": "AUS"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "553 St Kilda Road",
+            "locality": "Melbourne",
+            "country_a": "AUS"
+          }
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "status": "pass",
+      "user": "lily",
+      "issue": "https://github.com/pelias/pelias/issues/603",
+      "description": [
+        "match is found by removing neighborhood (WOF locality) Chácara Santo Antônio and "
+      ],
+      "in": {
+        "text": "Rua Henri Dunant 500 04709-110 São Paulo",
+        "boundary.country": "BRA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "500 Rua Henri Dunant",
+            "locality": "São Paulo",
+            "country_a": "BRA"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "Clayallee 170 14191 Berlin",
+        "boundary.country": "DEU"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Clayallee 170",
+            "locality": "Berlin",
+            "country_a": "DEU"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "Calle de Serrano 75 28006 Madrid",
+        "boundary.country": "ESP"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "75 Calle de Serrano",
+            "locality": "Madrid",
+            "country_a": "ESP"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "2 avenue Gabriel 75008 Paris",
+        "boundary.country": "FRA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "2 avenue Gabriel",
+            "locality": "Paris",
+            "country_a": "FRA"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "via Vittorio Veneto 121 00187 Roma",
+        "boundary.country": "ITA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "121 via Vittorio Veneto",
+            "locality": "Roma",
+            "country_a": "ITA"
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "490 Sussex Drive Ottawa K1N 1G8",
+        "boundary.country": "CAN"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "490 Sussex Drive",
+            "locality": "Ottawa",
+            "country_a": "CAN"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "24 Grosvenor Square London W1K 6AH",
+        "boundary.country": "GBR"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "24 Grosvenor Square",
+            "locality": "London",
+            "country_a": "GBR"
+          }
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "status": "pass",
+      "user": "lily",
+      "in": {
+        "text": "Prolongación Ave. Alfonso Reyes #150 Col. Valle del Poniente Santa Catarina 66196",
+        "boundary.country": "MEX"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "150 Prolongacion Avenida Alfonso Reyes",
+            "locality": "Ciudad Santa Catarina",
+            "country_a": "MEX"
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "status": "pass",
+      "user": "lily",
+      "description": [
+        "Russian street name in native langauge passes"
+      ],
+      "in": {
+        "text": "15 Фурштатская улица Saint Petersburg 191028",
+        "boundary.country": "RUS"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "15 Фурштатская улица",
+            "locality": "Saint Petersburg",
+            "country_a": "RUS"
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "status": "fail",
+      "user": "Lily",
+      "type": "dev",
+      "issue": "https://github.com/pelias/api/issues/783",
+      "description": [
+        "not recognized: spanish abbreviation av. for avenida. Similar problem with Brazilian addresses (Portuguese)"
+      ],
+      "in": {
+        "text": "Av. Juárez, Guadalajara, México"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Avenida Juárez",
+            "region": "Jalisco",
+            "country": "Mexico"
+          }
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "status": "fail",
+      "user": "lily",
+      "description": [
+        "fallsback to street centroid",
+        "Brazilian addresses generally fail because they are composed of street intersections"
+      ],
+      "in": {
+        "text": "Rua Gonçalves Maia 163 – Boa Vista 50070-060 Recife",
+        "boundary.country": "BRA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Rua Gonçalves Maia 163",
+            "locality": "Recife",
+            "country_a": "BRA"
+          }
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "status": "fail",
+      "user": "lily",
+      "description": [
+        "prod missing locality data. passes on prodbuild"
+      ],
+      "in": {
+        "text": "615 MacLeod Trail S.E. 10th Floor Calgary T2G 4T8",
+        "boundary.country": "CAN"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "615 MacLeod Trail",
+            "locality": "Calgary",
+            "country_a": "CAN"
+          }
+        ]
+      }
+    },
+    {
+      "id": 13,
+      "status": "fail",
+      "user": "lily",
+      "description": [
+        "Eliminate abbreviation in parens. Gets neighborhood, Kurla East, instead of a venue"
+      ],
+      "in": {
+        "text": "Bandra Kurla Complex Mumbai 400051",
+        "boundary.country": "IND"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Bandra Kurla Complex (BKC)",
+            "locality": "Mumbai",
+            "country_a": "IND"
+          }
+        ]
+      }
+    },
+    {
+      "id": 14,
+      "status": "fail",
+      "user": "lily",
+      "description": [
+        "Street exists in OSM data but returns various addresses instead of street centroid"
+      ],
+      "in": {
+        "text": "Paseo de la Reforma Colonia Cuauhtemoc Mexico D.F. 06500",
+        "boundary.country": "MEX"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Paseo de la Reforma",
+            "locality": "Mexico City",
+            "country_a": "MEX"
+          }
+        ]
+      }
+    },
+    {
+      "id": 15,
+      "status": "fail",
+      "user": "lily",
+      "issue": "https://github.com/pelias/pelias/issues/603",
+      "description": [
+        "Including the neighborhood, Col. Americana, causes falling back to the locaity"
+      ],
+      "in": {
+        "text": "Progreso 175 Col. Americana Guadalajara 44160",
+        "boundary.country": "MEX"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Progreso 175",
+            "locality": "Guadalajara",
+            "country_a": "MEX"
+          }
+        ]
+      }
+    },
+    {
+      "id": 16,
+      "status": "fail",
+      "user": "lily",
+      "issue": "https://github.com/pelias/api/issues/127",
+      "description": [
+        "Russian street name does not exist in English"
+      ],
+      "in": {
+        "text": "32 Pushkinskaya St. Vladivostok 690001",
+        "boundary.country": "RUS"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "32 Pushkinskaya St.",
+            "locality": "Vladivostok",
+            "country_a": "RUS"
+          }
+        ]
+      }
+    },
+    {
+      "id": 17,
+      "status": "fail",
+      "user": "lily",
+      "description": [
+        "housenumber has a slash. Falls back to street centroid. The building next to it has housenumber 2"
+      ],
+      "in": {
+        "text": "via Principe Amedeo 2/10 20121 MILANO",
+        "boundary.country": "ITA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "via Principe Amedeo 2/10",
+            "locality": "Milano",
+            "country_a": "ITA"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This set of acceptance tests asses how well Pelias does with addresses outside of the US. 

Source: https://www.usembassy.gov/

One passing address query from each country (10 total). India did not have any address that passed (from the selection of US Embassy addresses)

The other 8 fail for these reasons: 

1. Non-English abbreviation for street, avenue, etc
2. Brazilian street-intersection address format
3. Missing locality data for an address
4. Venue name has abbreviation in parens. "Bandra Kurla Complex (BKC)" Not including the abbreviation (Bandra Kurla Complex) returns a neighborhood.
5. Street exists in OSM data but returns various addresses instead of street centroid
6. Including neighborhood in address causes falling back to locality. Referenced in https://github.com/pelias/pelias/issues/603
7. No translation of street name to English
8. House number with slash