### PR TITLE
Point in Polygon related test tweaks 2017-09-26

### DIFF
--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -90,8 +90,10 @@
     },
     {
       "id": 7,
-      "status": "pass",
+      "status": "fail",
       "user": "missinglink",
+      "description": "hierarchy for the county of Erbil is missing in WOF",
+      "issue": "https://github.com/pelias/wof-admin-lookup/issues/156",
       "in": {
         "text": "Erbil, Iraq"
       },

--- a/test_cases/reverse_coarse.json
+++ b/test_cases/reverse_coarse.json
@@ -69,7 +69,7 @@
           {
             "layer": "locality",
             "locality": "San Juan",
-            "county": "Municipio de San Juan",
+            "county": "San Juan",
             "region": "Puerto Rico",
             "dependency": "Puerto Rico",
             "label": "San Juan, Puerto Rico"

--- a/test_cases/reverse_coarse.json
+++ b/test_cases/reverse_coarse.json
@@ -383,7 +383,7 @@
         "properties": [
           {
             "gid": "whosonfirst:county:1108735021",
-            "name": "Maksatikhinskij"
+            "name": "Maksatikhinskiy"
           }
         ]
       }
@@ -402,7 +402,7 @@
         "properties": [
           {
             "gid": "whosonfirst:region:85687359",
-            "name": "Setúbal"
+            "name": "Setúbal District"
           }
         ]
       }

--- a/test_cases/wof_neighbourhoods.json
+++ b/test_cases/wof_neighbourhoods.json
@@ -122,8 +122,8 @@
           {
             "layer": "neighbourhood",
             "name": "Taman Taynton View",
-            "locality": "Cheras",
-            "region": "Selangor",
+            "locality": "Kuala Lumpur",
+            "region": "Kuala Lumpur",
             "country": "Malaysia",
             "country_a": "MYS"
           }


### PR DESCRIPTION
This PR updates our acceptance tests for PIP related changes.

There is one case of a previously working test failing because the new admin lookup strategy has exposed a broken WOF hierarchy, as well as some name changes. One other test is changed to reflect an updated hierarchy, which may have also been because of our admin lookup changes.