### PR TITLE
Adjust tests for mostly Placeholder changes

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -14,7 +14,7 @@
       "expected": {
         "properties": [
           {
-            "county": "Voelkermarkt"
+            "county": "Völkermarkt"
           }
         ]
       },

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -294,7 +294,8 @@
         "priorityThresh": 1,
         "properties": [
           {
-            "label": "Malmö, Sweden"
+            "name": "Malmo",
+            "country": "Sweden"
           }
         ]
       }

--- a/test_cases/encoding.json
+++ b/test_cases/encoding.json
@@ -28,17 +28,16 @@
       "description": "make sure that results return the appropriate accents on results",
       "notes": "https://github.com/pelias/api/issues/731",
       "in": {
+        "lang": "et",
         "text": "pärnu, estonia"
       },
       "expected": {
         "priorityThresh": 2,
         "properties": [
           {
-            "name": "Parnu",
-            "region": "Pärnu County",
-            "locality": "Parnu",
-            "label": "Parnu, Estonia",
-            "country": "Estonia"
+            "name": "Pärnu maakond",
+            "region": "Pärnu maakond",
+            "country": "Eesti"
           }
         ]
       }

--- a/test_cases/encoding.json
+++ b/test_cases/encoding.json
@@ -34,7 +34,7 @@
         "properties": [
           {
             "name": "Parnu",
-            "region": "Pärnumaa",
+            "region": "Pärnu County",
             "locality": "Parnu",
             "label": "Parnu, Estonia",
             "country": "Estonia"
@@ -61,7 +61,7 @@
         "properties": [
           {
             "name": "Chambéry",
-            "macroregion": "Rhône-Alpes",
+            "macroregion": "Auvergne-Rhone-Alpes",
             "locality": "Chambéry",
             "label": "Chambéry, France",
             "country": "France"

--- a/test_cases/encoding.json
+++ b/test_cases/encoding.json
@@ -31,6 +31,7 @@
         "text": "pärnu, estonia"
       },
       "expected": {
+        "priorityThresh": 2,
         "properties": [
           {
             "name": "Parnu",

--- a/test_cases/international.json
+++ b/test_cases/international.json
@@ -282,7 +282,7 @@
     },
     {
       "id": 14,
-      "status": "fail",
+      "status": "pass",
       "user": "lily",
       "description": [
         "Street exists in OSM data but returns various addresses instead of street centroid"
@@ -295,6 +295,7 @@
         "properties": [
           {
             "name": "Paseo de la Reforma",
+            "layer": "street",
             "locality": "Mexico City",
             "country_a": "MEX"
           }

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -273,9 +273,12 @@
     },
     {
       "id": 19,
-      "status": "pass",
+      "status": "fail",
       "description": "locality in non-US dependency should still include country",
-      "issue": "https://github.com/pelias/labels/issues/5",
+      "issue": [
+        "https://github.com/pelias/labels/issues/5",
+        "https://github.com/pelias/placeholder/issues/54"
+      ],
       "user": "trescube",
       "in": {
         "text": "George Hill, Anguilla",
@@ -293,9 +296,12 @@
     },
     {
       "id": 20,
-      "status": "pass",
+      "status": "fail",
       "description": "locality in non-US dependency should still include country",
-      "issue": "https://github.com/pelias/labels/issues/5",
+      "issue": [
+        "https://github.com/pelias/labels/issues/5",
+        "https://github.com/pelias/placeholder/issues/54"
+      ],
       "user": "trescube",
       "in": {
         "text": "Tórshavn faroe islands",

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -247,7 +247,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Bayamón, PRI"
+            "label": "Bayamón, Puerto Rico"
           }
         ]
       }
@@ -266,7 +266,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Aasu, ASM"
+            "label": "Aasu, American Samoa"
           }
         ]
       }

--- a/test_cases/placeholder_altnames.json
+++ b/test_cases/placeholder_altnames.json
@@ -69,7 +69,7 @@
     },
     {
       "id": 3,
-      "status": "fail",
+      "status": "pass",
       "user": "lily",
       "description": [
         "address in French with admin info in Japanese",
@@ -132,7 +132,7 @@
     },
     {
       "id": 6,
-      "status": "fail",
+      "status": "pass",
       "user": "lily",
       "endpoint": "autocomplete",
       "description": [
@@ -252,7 +252,7 @@
     },
     {
       "id": 11,
-      "status": "fail",
+      "status": "pass",
       "user": "lily",
       "description": [
         "address in Estonian, locality (Tallinn) in Finnish, region in English"
@@ -313,7 +313,7 @@
         "properties": [
           {
             "name": "Беверли Хилс",
-            "region": "Texas",
+            "region": "Тексас",
             "country": "Сједињене Америчке Државе"
           }
         ]
@@ -325,7 +325,6 @@
       "user": "lily",
       "description": [
         "search with focus point parameter",
-        "no RU translation for region",
         "lang: russian"
       ],
       "in": {
@@ -338,7 +337,7 @@
         "properties": [
           {
             "name": "Спрингфилд",
-            "region": "Ohio",
+            "region": "Огайо",
             "country": "Соединённые Штаты Америки"
           }
         ]
@@ -430,7 +429,7 @@
         "properties": [
           {
             "name": "Дамаскъс",
-            "region": "Oregon",
+            "region": "Орегон",
             "country": "Съединени американски щати"
           }
         ]

--- a/test_cases/placeholder_altnames.json
+++ b/test_cases/placeholder_altnames.json
@@ -594,7 +594,25 @@
           }
         ]
       }
+    },
+    {
+      "id": 26,
+      "status": "pass",
+      "user": "julian",
+      "description": "from mapillary home page",
+      "in": {
+        "text": "malmo",
+        "lang": "sv"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          {
+            "name": "Malmö",
+            "country": "Sverige"
+          }
+        ]
+      }
     }
-
   ]
 }

--- a/test_cases/placeholder_general.json
+++ b/test_cases/placeholder_general.json
@@ -566,7 +566,7 @@
     },
     {
       "id": 28,
-      "status": "fail",
+      "status": "pass",
       "endpoint": "search",
       "description": "Dundee has 0 population: https://github.com/pelias/pelias/issues/526",
       "priorityThresh": 10,

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -552,9 +552,9 @@
     },
     {
       "id": 1101,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
-      "description": "county",
+      "description": "county. failed because of space temporarily at the end of the name",
       "in": {
         "text": "Nordsachsen"
       },

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -743,6 +743,26 @@
           }
         ]
       }
+    },
+    {
+      "id": 1600,
+      "status": "fail",
+      "endpoint": "search",
+      "description": "county should be after locality generally",
+      "issue": [
+        "https://github.com/pelias/placeholder/issues/55"
+      ],
+      "in": {
+        "text": "pärnu, estonia"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Parnu",
+            "layer": "locality"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -431,9 +431,10 @@
     },
     {
       "id": 701,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
       "description": "borough should rank higher than county",
+      "issue": "https://github.com/pelias/placeholder/issues/55",
       "in": {
         "text": "Queens"
       },

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -305,7 +305,7 @@
         "properties": [
           {
             "gid": "whosonfirst:macroregion:404227535",
-            "name": "Sardegna"
+            "name": "Sardinia"
           }
         ]
       }
@@ -322,7 +322,7 @@
         "properties": [
           {
             "gid": "whosonfirst:macroregion:404227361",
-            "name": "Andalucía"
+            "name": "Andalusia"
           }
         ]
       }

--- a/test_cases/search_city_country.json
+++ b/test_cases/search_city_country.json
@@ -179,10 +179,10 @@
     },
     {
       "id": 10,
-      "status": "fail",
+      "status": "pass",
       "user": "trescube",
       "type": "dev",
-      "notes": "WOF currently lacks 'Cairo' as an altname for the city: https://whosonfirst.mapzen.com/spelunker/id/421174399",
+      "notes": "WOF previously lacked 'Cairo' as an altname for the city: https://whosonfirst.mapzen.com/spelunker/id/421174399",
       "in": {
         "text": "Cairo, EGY"
       },

--- a/test_cases/search_city_country.json
+++ b/test_cases/search_city_country.json
@@ -494,10 +494,11 @@
     },
     {
       "id": 26,
-      "status": "pass",
+      "status": "fail",
       "user": "trescube",
       "type": "dev",
       "notes": "New Caledonia is a dependency",
+      "issue": "https://github.com/pelias/wof-admin-lookup/issues/156",
       "in": {
         "text": "Bourail, new caledonia"
       },

--- a/test_cases/search_city_country.json
+++ b/test_cases/search_city_country.json
@@ -250,7 +250,7 @@
           {
             "layer": "locality",
             "locality": "Prague",
-            "country": "Czech Republic",
+            "country": "Czechia",
             "country_a": "CZE"
           }
         ]

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -652,12 +652,12 @@
         "properties": [
           {
             "layer": "county",
-            "name": "Chongqing",
+            "name": "Chongqing Shi",
             "country_a": "CHN",
             "country": "China",
             "region": "Chongqing",
-            "county": "Chongqing",
-            "label": "Chongqing, China"
+            "county": "Chongqing Shi",
+            "label": "Chongqing Shi, China"
           }
         ]
       }

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -26,8 +26,7 @@
             "county": "Lancaster County",
             "locality": "Lancaster",
             "housenumber": "1090",
-            "street": "N Charlotte St",
-            "label": "1090 N Charlotte St, Lancaster, PA, USA"
+            "street": "N Charlotte St"
           }
         ]
       }
@@ -54,8 +53,7 @@
             "region_a": "PA",
             "county": "Lancaster County",
             "locality": "Lancaster",
-            "street": "North Charlotte Street",
-            "label": "North Charlotte Street, Lancaster, PA, USA"
+            "street": "North Charlotte Street"
           }
         ]
       }
@@ -85,8 +83,7 @@
             "region_a": "NM",
             "county": "Socorro County",
             "locality": "Socorro",
-            "street": "Calle de Lago",
-            "label": "Calle de Lago, Socorro, NM, USA"
+            "street": "Calle de Lago"
           }
         ]
       }
@@ -112,8 +109,7 @@
             "region": "Pennsylvania",
             "region_a": "PA",
             "county": "Lancaster County",
-            "locality": "Lancaster",
-            "label": "Lancaster, PA, USA"
+            "locality": "Lancaster"
           }
         ]
       }
@@ -138,8 +134,7 @@
             "country": "United States",
             "region": "California",
             "region_a": "CA",
-            "locality": "San Francisco",
-            "label": "1338 Kobbe Ave, San Francisco, CA, USA"
+            "locality": "San Francisco"
           }
         ]
       }
@@ -161,8 +156,7 @@
             "name": "Grolmanstraße 51",
             "country_a": "DEU",
             "country": "Germany",
-            "locality": "Berlin",
-            "label": "Grolmanstraße 51, Berlin, Germany"
+            "locality": "Berlin"
           }
         ]
       }
@@ -187,8 +181,7 @@
             "country": "United States",
             "region": "California",
             "region_a": "CA",
-            "locality": "San Francisco",
-            "label": "5 Russian Hill Pl, San Francisco, CA, USA"
+            "locality": "San Francisco"
           }
         ]
       }
@@ -232,8 +225,7 @@
             "region": "New York",
             "locality": "New York",
             "borough": "Brooklyn",
-            "neighbourhood": "DUMBO",
-            "label": "DUMBO, Brooklyn, New York, NY, USA"
+            "neighbourhood": "DUMBO"
           }
         ]
       }
@@ -257,8 +249,7 @@
             "region": "New York",
             "locality": "New York",
             "borough": "Manhattan",
-            "neighbourhood": "Chelsea",
-            "label": "Chelsea, Manhattan, New York, NY, USA"
+            "neighbourhood": "Chelsea"
           }
         ]
       }
@@ -282,8 +273,7 @@
             "region": "New York",
             "locality": "New York",
             "borough": "Manhattan",
-            "neighbourhood": "NoHo",
-            "label": "NoHo, Manhattan, New York, NY, USA"
+            "neighbourhood": "NoHo"
           }
         ]
       }
@@ -311,8 +301,7 @@
             "region_a": "NY",
             "county": "New York County",
             "locality": "New York",
-            "borough": "Manhattan",
-            "label": "Manhattan, New York, NY, USA"
+            "borough": "Manhattan"
           },
           {
             "layer": "locality",
@@ -322,8 +311,7 @@
             "region": "Kansas",
             "region_a": "KS",
             "county": "Riley County",
-            "locality": "Manhattan",
-            "label": "Manhattan, KS, USA"
+            "locality": "Manhattan"
           }
         ]
       }
@@ -352,8 +340,7 @@
             "region_a": "NY",
             "county": "New York County",
             "locality": "New York",
-            "borough": "Manhattan",
-            "label": "Manhattan, New York, NY, USA"
+            "borough": "Manhattan"
           }
         ]
       }
@@ -380,8 +367,7 @@
             "region": "New Mexico",
             "region_a": "NM",
             "county": "Socorro County",
-            "locality": "Socorro",
-            "label": "Socorro, NM, USA"
+            "locality": "Socorro"
           }
         ]
       }
@@ -406,8 +392,7 @@
             "country": "United States",
             "region": "New York",
             "region_a": "NY",
-            "locality": "New York",
-            "label": "New York, NY, USA"
+            "locality": "New York"
           }
         ]
       }
@@ -429,8 +414,7 @@
             "name": "Paris",
             "country_a": "FRA",
             "country": "France",
-            "locality": "Paris",
-            "label": "Paris, France"
+            "locality": "Paris"
           }
         ]
       }
@@ -452,8 +436,7 @@
             "name": "Beijing",
             "country_a": "CHN",
             "country": "China",
-            "locality": "Beijing",
-            "label": "Beijing, China"
+            "locality": "Beijing"
           }
         ]
       }
@@ -476,8 +459,7 @@
             "name": "Zickrick",
             "country_a": "USA",
             "country": "United States",
-            "localadmin": "Zickrick",
-            "label": "Zickrick, SD, USA"
+            "localadmin": "Zickrick"
           }
         ]
       }
@@ -499,8 +481,7 @@
             "name": "Zumbehl",
             "country_a": "USA",
             "country": "United States",
-            "localadmin": "Zumbehl",
-            "label": "Zumbehl, MO, USA"
+            "localadmin": "Zumbehl"
           }
         ]
       }
@@ -525,8 +506,7 @@
             "country": "United States",
             "region_a": "MN",
             "region": "Minnesota",
-            "localadmin": "Aastad",
-            "label": "Aastad, MN, USA"
+            "localadmin": "Aastad"
           }
         ]
       }
@@ -551,8 +531,7 @@
             "country": "United States",
             "region_a": "OH",
             "region": "Ohio",
-            "localadmin": "Bloominggrove",
-            "label": "Bloominggrove, OH, USA"
+            "localadmin": "Bloominggrove"
           }
         ]
       }
@@ -577,8 +556,7 @@
             "country_a": "USA",
             "country": "United States",
             "region_a": "PA",
-            "region": "Pennsylvania",
-            "label": "Lancaster County, PA, USA"
+            "region": "Pennsylvania"
           },
           {
             "layer": "county",
@@ -586,8 +564,7 @@
             "country_a": "USA",
             "country": "United States",
             "region_a": "NE",
-            "region": "Nebraska",
-            "label": "Lancaster County, NE, USA"
+            "region": "Nebraska"
           }
         ]
       }
@@ -610,8 +587,7 @@
             "country_a": "USA",
             "country": "United States",
             "region_a": "PA",
-            "region": "Pennsylvania",
-            "label": "Lancaster County, PA, USA"
+            "region": "Pennsylvania"
           }
         ]
       }
@@ -632,8 +608,7 @@
             "name": "L'Hermenault",
             "country_a": "FRA",
             "country": "France",
-            "region": "Vendée",
-            "label": "L'Hermenault, France"
+            "region": "Vendée"
           }
         ]
       }
@@ -656,8 +631,7 @@
             "country_a": "CHN",
             "country": "China",
             "region": "Chongqing",
-            "county": "Chongqing Shi",
-            "label": "Chongqing Shi, China"
+            "county": "Chongqing Shi"
           }
         ]
       }
@@ -679,8 +653,7 @@
             "name": "Gießen",
             "country_a": "DEU",
             "country": "Germany",
-            "macrocounty": "Gießen",
-            "label": "Gießen, Germany"
+            "macrocounty": "Gießen"
           }
         ]
       }
@@ -702,8 +675,7 @@
             "name": "Mittelfranken",
             "country_a": "DEU",
             "country": "Germany",
-            "macrocounty": "Mittelfranken",
-            "label": "Mittelfranken, Germany"
+            "macrocounty": "Mittelfranken"
           }
         ]
       }
@@ -724,8 +696,7 @@
             "name": "Arnsberg",
             "country_a": "DEU",
             "country": "Germany",
-            "macrocounty": "Arnsberg",
-            "label": "Arnsberg, Germany"
+            "macrocounty": "Arnsberg"
           }
         ]
       }
@@ -749,8 +720,7 @@
             "country_a": "USA",
             "country": "United States",
             "region_a": "PA",
-            "region": "Pennsylvania",
-            "label": "Pennsylvania, USA"
+            "region": "Pennsylvania"
           }
         ]
       }
@@ -772,8 +742,7 @@
             "country_a": "USA",
             "country": "United States",
             "region_a": "NM",
-            "region": "New Mexico",
-            "label": "New Mexico, USA"
+            "region": "New Mexico"
           }
         ]
       }
@@ -794,8 +763,7 @@
             "name": "Kakheti",
             "country_a": "GEO",
             "country": "Georgia",
-            "region": "Kakheti",
-            "label": "Kakheti, Georgia"
+            "region": "Kakheti"
           }
         ]
       }
@@ -841,8 +809,7 @@
             "name": "Marche",
             "country_a": "ITA",
             "country": "Italy",
-            "macroregion": "Marche",
-            "label": "Marche, Italy"
+            "macroregion": "Marche"
           }
         ]
       }
@@ -863,8 +830,7 @@
             "name": "Marche",
             "country_a": "ITA",
             "country": "Italy",
-            "macroregion": "Marche",
-            "label": "Marche, Italy"
+            "macroregion": "Marche"
           }
         ]
       }
@@ -886,8 +852,7 @@
             "name": "Northern Finland",
             "country_a": "FIN",
             "country": "Finland",
-            "macroregion": "Northern Finland",
-            "label": "Northern Finland, Finland"
+            "macroregion": "Northern Finland"
           }
         ]
       }
@@ -908,8 +873,7 @@
           {
             "layer": "dependency",
             "name": "US Virgin Islands",
-            "dependency": "US Virgin Islands",
-            "label": "US Virgin Islands"
+            "dependency": "US Virgin Islands"
           }
         ]
       }
@@ -929,8 +893,7 @@
           {
             "layer": "dependency",
             "name": "US Virgin Islands",
-            "dependency": "US Virgin Islands",
-            "label": "US Virgin Islands"
+            "dependency": "US Virgin Islands"
           }
         ]
       }
@@ -949,8 +912,7 @@
           {
             "layer": "dependency",
             "name": "Bermuda",
-            "dependency": "Bermuda",
-            "label": "Bermuda"
+            "dependency": "Bermuda"
           }
         ]
       }
@@ -971,8 +933,7 @@
             "layer": "country",
             "name": "United States",
             "country_a": "USA",
-            "country": "United States",
-            "label": "United States"
+            "country": "United States"
           }
         ]
       }
@@ -992,8 +953,7 @@
             "layer": "country",
             "name": "United States",
             "country_a": "USA",
-            "country": "United States",
-            "label": "United States"
+            "country": "United States"
           }
         ]
       }
@@ -1013,8 +973,7 @@
             "layer": "country",
             "name": "United States",
             "country_a": "USA",
-            "country": "United States",
-            "label": "United States"
+            "country": "United States"
           }
         ]
       }
@@ -1035,8 +994,7 @@
             "layer": "country",
             "name": "Thailand",
             "country_a": "THA",
-            "country": "Thailand",
-            "label": "Thailand"
+            "country": "Thailand"
           }
         ]
       }
@@ -1056,8 +1014,7 @@
             "layer": "country",
             "name": "France",
             "country_a": "FRA",
-            "country": "France",
-            "label": "France"
+            "country": "France"
           }
         ]
       }
@@ -1078,8 +1035,7 @@
             "layer": "country",
             "name": "Australia",
             "country_a": "AUS",
-            "country": "Australia",
-            "label": "Australia"
+            "country": "Australia"
           }
         ]
       }
@@ -1103,8 +1059,7 @@
             "layer": "venue",
             "name": "Lancaster Bureau of Police",
             "locality": "Lancaster",
-            "region_a": "PA",
-            "label": "Lancaster Bureau of Police, Lancaster, PA, USA"
+            "region_a": "PA"
           }
         ]
       }
@@ -1127,8 +1082,7 @@
             "layer": "venue",
             "name": "Chameleon Club",
             "locality": "Lancaster",
-            "region_a": "PA",
-            "label": "Chameleon Club, Lancaster, PA, USA"
+            "region_a": "PA"
           }
         ]
       }
@@ -1151,8 +1105,7 @@
             "layer": "venue",
             "name": "Lancaster Bureau of Police",
             "locality": "Lancaster",
-            "region_a": "PA",
-            "label": "Lancaster Bureau of Police, Lancaster, PA, USA"
+            "region_a": "PA"
           }
         ]
       }
@@ -1176,8 +1129,7 @@
             "housenumber": "1090",
             "street": "N Charlotte St",
             "locality": "Lancaster",
-            "region_a": "PA",
-            "label": "1090 N Charlotte St, Lancaster, PA, USA"
+            "region_a": "PA"
           }
         ]
       }
@@ -1200,8 +1152,7 @@
             "layer": "street",
             "street": "North Charlotte Street",
             "locality": "Lancaster",
-            "region_a": "PA",
-            "label": "North Charlotte Street, Lancaster, PA, USA"
+            "region_a": "PA"
           }
         ]
       }
@@ -1222,8 +1173,7 @@
           {
             "layer": "locality",
             "locality": "Lancaster",
-            "region_a": "PA",
-            "label": "Lancaster, PA, USA"
+            "region_a": "PA"
           }
         ]
       }

--- a/test_cases/university.json
+++ b/test_cases/university.json
@@ -130,7 +130,7 @@
     },
     {
       "id": 6,
-      "status": "fail",
+      "status": "pass",
       "user": "Lily",
       "type": "dev",
       "description": [

--- a/test_cases/wof_counties.json
+++ b/test_cases/wof_counties.json
@@ -70,7 +70,7 @@
             "county": "Arzacq-Arraziguet",
             "macrocounty": "Pau",
             "region": "Pyrénées-Atlantiques",
-            "macroregion": "Aquitaine",
+            "macroregion": "New Aquitaine",
             "country": "France",
             "country_a": "FRA"
           }

--- a/test_cases/wof_localadmins.json
+++ b/test_cases/wof_localadmins.json
@@ -4,9 +4,9 @@
   "tests": [
     {
       "id": 1,
-      "status": "pass",
+      "status": "fail",
       "user": "Stephen",
-      "description": "chosen for diacriticals",
+      "description": "chosen for diacriticals. space at the end of the name",
       "in": {
         "text": "Villares De Órbigo, Spain",
         "sources": "wof",
@@ -17,7 +17,7 @@
           {
             "layer": "localadmin",
             "name": "Villares De Órbigo",
-            "region": "León",
+            "region": "Leon",
             "macroregion": "Castile and Leon",
             "country": "Spain",
             "country_a": "ESP"

--- a/test_cases/wof_localadmins.json
+++ b/test_cases/wof_localadmins.json
@@ -18,7 +18,7 @@
             "layer": "localadmin",
             "name": "Villares De Órbigo",
             "region": "León",
-            "macroregion": "Castilla Y León",
+            "macroregion": "Castile and Leon",
             "country": "Spain",
             "country_a": "ESP"
           }

--- a/test_cases/wof_macroregions.json
+++ b/test_cases/wof_macroregions.json
@@ -15,8 +15,8 @@
         "properties": [
           {
             "layer": "macroregion",
-            "name": "Észak-Alföld",
-            "macroregion": "Észak-Alföld",
+            "name": "Northern Great Plain",
+            "macroregion": "Northern Great Plain",
             "country": "Hungary",
             "country_a": "HUN"
           }
@@ -36,8 +36,8 @@
         "properties": [
           {
             "layer": "macroregion",
-            "name": "Comunidad Foral De Navarra",
-            "macroregion": "Comunidad Foral De Navarra",
+            "name": "Navarra",
+            "macroregion": "Navarra",
             "country": "Spain",
             "country_a": "ESP"
           }
@@ -57,8 +57,8 @@
         "properties": [
           {
             "layer": "macroregion",
-            "name": "Île-De-France",
-            "macroregion": "Île-De-France",
+            "name": "Ile-of-France",
+            "macroregion": "Ile-of-France",
             "country": "France",
             "country_a": "FRA"
           }
@@ -100,8 +100,8 @@
         "properties": [
           {
             "layer": "macroregion",
-            "name": "Sardegna",
-            "macroregion": "Sardegna",
+            "name": "Sardinia",
+            "macroregion": "Sardinia",
             "country": "Italy",
             "country_a": "ITA"
           }
@@ -121,8 +121,8 @@
         "properties": [
           {
             "layer": "macroregion",
-            "name": "Közép-Magyarország",
-            "macroregion": "Közép-Magyarország",
+            "name": "Central Hungary",
+            "macroregion": "Central Hungary",
             "country": "Hungary",
             "country_a": "HUN"
           }

--- a/test_cases/wof_neighbourhoods.json
+++ b/test_cases/wof_neighbourhoods.json
@@ -79,7 +79,7 @@
           {
             "layer": "neighbourhood",
             "name": "Gaddiannaram",
-            "locality": "Hyderābād",
+            "locality": "Hyderabad",
             "region": "Andhra Pradesh",
             "country": "India",
             "country_a": "IND"


### PR DESCRIPTION
This PR adjusts our acceptance tests for all recent Placeholder changes.

In general, many translations have been updated and in many cases English translations have been added, often ones that have no accents or diacriticals.

A few regressions have happened, mostly around sorting such as https://github.com/pelias/placeholder/issues/55.
Two tests are temporarily marked failing because the names somehow had trailing spaces added, but both cases have been fixed via Boundary Issues and should resolve soon.

With this, combined with the changes in https://github.com/pelias/acceptance-tests/pull/434 and https://github.com/pelias/acceptance-tests/pull/437, which handle PIP and empire/dependency related issues respectively, we should be pretty much back to zero failing tests.

This PR can be tested against Mapzen Search `dev` only, as nowhere else has updated placeholder data
