### PR TITLE
Add tests for `/reverse` endpoint's ability to return venues

### DIFF
--- a/test_cases/reverse_venue.json
+++ b/test_cases/reverse_venue.json
@@ -1,0 +1,71 @@
+{
+  "name": "reverse venues",
+  "priorityThresh": 1,
+  "endpoint": "reverse",
+  "tests": [
+    {
+      "id": 1,
+      "status": "fail",
+      "user": "julian",
+      "description": "until we finalize the /nearby endpoint, /reverse should still be able to return Geonames venues",
+      "issue": "https://github.com/pelias/api/issues/930",
+      "in": {
+        "point.lat": 47.417,
+        "point.lon": 10.75,
+        "layers": "venue",
+        "sources": "geonames"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Axljoch Berg",
+            "layer": "venue",
+            "source": "geonames"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "julian",
+      "description": "until we finalize the /nearby endpoint, /reverse should still be able to return Geonames venues, even with no source specified",
+      "issue": "https://github.com/pelias/api/issues/930",
+      "in": {
+        "point.lat": 47.417,
+        "point.lon": 10.75,
+        "layers": "venue"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Axljoch Berg",
+            "layer": "venue",
+            "source": "geonames"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "user": "julian",
+      "description": "until we finalize the /nearby endpoint, /reverse should still be able to return OSM venues",
+      "issue": "https://github.com/pelias/api/issues/930",
+      "in": {
+        "point.lat": -13.1748,
+        "point.lon": -72.56463,
+        "layers": "venue"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Machu Picchu",
+            "layer": "venue",
+            "source": "openstreetmap"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Until we finalize the `/nearby` endpoint, `/reverse` should be able to return venues, including Geonames venues.

Once `/nearby` is ready, we can remove this support and have `/reverse` support only address and coarse results, as specified in the [design document](https://github.com/pelias/pelias/wiki/Reverse-Geocoding,-Part-Deux).

This PR adds tests for returning venues, both Geonames and OSM, from `/reverse`.

Connects https://github.com/pelias/api/issues/930