### PR TITLE
Run precommit checks on TravisCI instead of calling Mapzen Search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
-before_script:
-    - npm prune
-    - 'echo "{ \"mapzen\": { \"api_key\": { \"search.mapzen.com\": \"$API_KEY\" } } }" > ~/pelias.json'
 node_js:
   - 6
 sudo: false
+script: npm run lint && npm ls
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
The TravisCI jobs for the pelias/acceptance-tests repo have historically
passed only if running all the tests against Mapzen Search production
passed.

There were many problems with this:
1. Branches with acceptance tests for new features would always fail
2. If there was any issue with Mapzen Search, the tests could fail
3. It assumed Mapzen Search will continue to exist!

As of today, number 3 in that list is no longer true, so now the
acceptance tests will always fail in Travis.

This PR changes the Travis tests to instead perform the same checks as
our precommit hooks: validate that the NPM package installation looks
good, and the code in this repo doesn't violate our JSHint rules.

Connects https://github.com/pelias/pelias/issues/703