### PR TITLE
Source field acceptance tests

### DIFF
--- a/test_cases/search_sources.json
+++ b/test_cases/search_sources.json
@@ -1,7 +1,7 @@
 {
   "name": "search sources",
   "endpoint": "search",
-  "priorityThresh": 2,
+  "priorityThresh": 9,
   "tests": [
     {
       "id": "1",

--- a/test_cases/search_sources.json
+++ b/test_cases/search_sources.json
@@ -1,7 +1,7 @@
 {
   "name": "search sources",
   "endpoint": "search",
-  "priorityThresh": Infinity,
+  "priorityThresh": 2,
   "tests": [
     {
       "id": "1",

--- a/test_cases/search_sources.json
+++ b/test_cases/search_sources.json
@@ -1,0 +1,24 @@
+{
+  "name": "search sources",
+  "tests": [
+    {
+      "id": "1",
+      "status": "pass",
+      "user": "tiranno",
+      "endpoint": "search",
+      "description": "Ensure there are only geonames records when filtering for geonames",
+      "issue": "https://github.com/pelias/pelias/issues/670",
+      "in": {
+        "text": "portland",
+        "source": "gn"
+      },
+      "expected": {
+        "properties": [
+          {
+            "source": "geonames"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test_cases/search_sources.json
+++ b/test_cases/search_sources.json
@@ -1,21 +1,40 @@
 {
   "name": "search sources",
+  "endpoint": "search",
+  "priorityThresh": 1,
   "tests": [
     {
       "id": "1",
       "status": "pass",
       "user": "tiranno",
-      "endpoint": "search",
       "description": "Ensure there are only geonames records when filtering for geonames",
       "issue": "https://github.com/pelias/pelias/issues/670",
       "in": {
-        "text": "portland",
-        "source": "gn"
+        "text": "Portland, OR",
+        "source": "geonames"
       },
       "expected": {
         "properties": [
           {
             "source": "geonames"
+          }
+        ]
+      }
+    },
+    {
+      "id": "2",
+      "status": "pass",
+      "user": "tiranno",
+      "description": "Ensure there are only whosonfirst records when filtering for whosonfirst",
+      "issue": "https://github.com/pelias/pelias/issues/670",
+      "in": {
+        "text": "Portland, OR",
+        "sources": "whosonfirst"
+      },
+      "expected": {
+        "properties": [
+          {
+            "source": "whosonfirst"
           }
         ]
       }

--- a/test_cases/search_sources.json
+++ b/test_cases/search_sources.json
@@ -4,14 +4,29 @@
   "priorityThresh": 9,
   "tests": [
     {
-      "id": "1",
+      "id": 1,
       "status": "pass",
-      "user": "tiranno",
-      "description": "Ensure there are only geonames records when filtering for geonames",
-      "issue": "https://github.com/pelias/pelias/issues/670",
+      "endpoint": "search",
+      "description": "Admin-only query with undefined `sources` should return WhosOnFirst",
       "in": {
         "text": "Portland, OR",
-        "source": "geonames"
+      },
+      "expected": {
+        "properties": [
+          {
+            "source": "whosonfirst",
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "pass",
+      "endpoint": "search",
+      "description": "Admin-only query requesting Geonames returns only Geonames",
+      "in": {
+        "text": "Portland, OR",
+        "sources": "geonames"
       },
       "expected": {
         "properties": [
@@ -22,11 +37,10 @@
       }
     },
     {
-      "id": "2",
+      "id": 3,
       "status": "pass",
-      "user": "tiranno",
-      "description": "Ensure there are only whosonfirst records when filtering for whosonfirst",
-      "issue": "https://github.com/pelias/pelias/issues/670",
+      "endpoint": "search",
+      "description": "Admin-only query requesting WhosOnFirst returns only WhosOnFirst",
       "in": {
         "text": "Portland, OR",
         "sources": "whosonfirst"

--- a/test_cases/search_sources.json
+++ b/test_cases/search_sources.json
@@ -1,7 +1,7 @@
 {
   "name": "search sources",
   "endpoint": "search",
-  "priorityThresh": 1,
+  "priorityThresh": Infinity,
   "tests": [
     {
       "id": "1",


### PR DESCRIPTION
Tests that cover requests when `sources` is present.
Currently includes Geonames-only and WhosOnFirst-only requests