### PR TITLE
Periodic cleaning

### DIFF
--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -232,7 +232,8 @@
     },
     {
       "id": 9,
-      "status": "fail",
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/748",
       "user": "missinglink",
       "in": {
         "text": "california"

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -201,7 +201,7 @@
     },
     {
       "id": 15,
-      "status": "fail",
+      "status": "pass",
       "description": "geonnames localadmin records should not have borough or locality component in label",
       "issue": [ "https://github.com/pelias/wof-admin-lookup/issues/49",
                  "https://github.com/pelias/wof-admin-lookup/issues/220" ],

--- a/test_cases/search_city_country.json
+++ b/test_cases/search_city_country.json
@@ -545,7 +545,7 @@
         "text": "Vientiane, laos"
       },
       "expected": {
-        "priorityThresh": 2,
+        "priorityThresh": 3,
         "properties": [
           {
             "layer": "locality",

--- a/test_cases/search_coarse.json
+++ b/test_cases/search_coarse.json
@@ -25,7 +25,7 @@
       "id": 2,
       "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/295",
-      "description": "data issue",
+      "description": "data issue: new york city was parented by brooklyn in early WOF data",
       "user": "Diana",
       "type": "dev",
       "in": {

--- a/test_cases/search_coarse.json
+++ b/test_cases/search_coarse.json
@@ -36,9 +36,6 @@
       "expected": {
         "properties": [
           {
-            "label": "New York, USA"
-          },
-          {
             "label": "New York, NY, USA"
           }
         ]

--- a/test_cases/search_geodisambiguation.json
+++ b/test_cases/search_geodisambiguation.json
@@ -17,7 +17,7 @@
         "priorityThresh": 2,
         "properties": [
           {
-            "layer": "localadmin",
+            "layer": "locality",
             "name": "Aliquippa",
             "region": "Pennsylvania",
             "region_a": "PA",

--- a/test_cases/search_postalcodes.json
+++ b/test_cases/search_postalcodes.json
@@ -66,6 +66,31 @@
       }
     },
     {
+      "id": "searchpostal-3.1",
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/692",
+      "user": "diana",
+      "in": {
+        "text": "M2M1C8"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "M2M 1C8",
+            "postalcode": "M2M 1C8",
+            "postalcode_gid": "whosonfirst:postalcode:521433719",
+            "confidence": 1,
+            "match_type": "exact",
+            "accuracy": "centroid",
+            "country": "Canada",
+            "region": "Ontario",
+            "locality": "Toronto",
+            "label": "M2M 1C8, Toronto, ON, Canada"
+          }
+        ]
+      }
+    },
+    {
       "id": "searchpostal-4",
       "status": "fail",
       "issue": "https://github.com/pelias/pelias/issues/692",

--- a/test_cases/search_postalcodes.json
+++ b/test_cases/search_postalcodes.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "id": "searchpostal-1",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/692",
       "user": "diana",
       "in": {

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -548,7 +548,7 @@
 
     {
       "id": 500,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/wof-admin-lookup/issues/220",
       "user": "trescube",
       "type": "dev",

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -240,6 +240,7 @@
         "neighbourhood": "Chelsea"
       },
       "expected": {
+        "priorityThresh": 2,
         "properties": [
           {
             "layer": "neighbourhood",
@@ -249,6 +250,13 @@
             "region": "New York",
             "locality": "New York",
             "borough": "Manhattan",
+            "neighbourhood": "Chelsea"
+          },
+          {
+            "layer": "neighbourhood",
+            "name": "Chelsea",
+            "country_a": "GBR",
+            "locality": "London",
             "neighbourhood": "Chelsea"
           }
         ]

--- a/test_cases/wof_counties.json
+++ b/test_cases/wof_counties.json
@@ -56,7 +56,7 @@
       "id": 4,
       "status": "pass",
       "user": "Stephen",
-      "description": "chosen because France and complicated hierarchy",
+      "description": "chosen because France and complicated hierarchy. This county exists but should be deduped with the localadmin of the same name",
       "in": {
         "text": "Arzacq-Arraziguet",
         "sources": "wof"
@@ -65,7 +65,7 @@
         "priorityThresh": 2,
         "properties": [
           {
-            "layer": "county",
+            "layer": "localadmin",
             "name": "Arzacq-Arraziguet",
             "county": "Arzacq-Arraziguet",
             "macrocounty": "Pau",

--- a/test_cases/wof_regions.json
+++ b/test_cases/wof_regions.json
@@ -94,7 +94,7 @@
       "id": 5,
       "status": "pass",
       "user": "Stephen",
-      "description": "",
+      "description": "while it's a region, the region should be deduped with the county of the same name",
       "in": {
         "text": "Dadra and Nagar Haveli, IN",
         "sources": "wof"
@@ -102,7 +102,7 @@
       "expected": {
         "properties": [
           {
-            "layer": "region",
+            "layer": "county",
             "name": "Dadra and Nagar Haveli",
             "region": "Dadra and Nagar Haveli",
             "country": "India",


### PR DESCRIPTION
This is your regularly scheduled acceptance test update. It includes a few minor improvements to some tests, and updates tests that are now passing.

The most significant change is that thanks to https://github.com/pelias/api/pull/1230 many queries returned results that are improved via deduplication. Often this results in more-granular results (such as a locality instead of a locality and county with the same name).