### PR TITLE
February updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "validate": "npm ls"
   },
   "dependencies": {
-    "pelias-fuzzy-tester": "^1.0.0"
+    "pelias-fuzzy-tester": "^1.5.0"
   },
   "devDependencies": {
     "jshint": "^2.9.4",

--- a/test_cases/address_matching.json
+++ b/test_cases/address_matching.json
@@ -50,6 +50,7 @@
         "text": "49 Kay Street"
       },
       "expected": {
+        "priorityThresh": 2,
         "properties": [
           {
             "street": "Kay Street"
@@ -66,7 +67,22 @@
           },
           {
             "street": "Kay Road"
-          },
+          }
+        ]
+      }
+    },
+    {
+      "id": 3.1,
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/296",
+      "description": "De Kay Street can be returned, but should be lower than exact match 'Kay St'",
+      "user": "orangejulius",
+      "type": "dev",
+      "in": {
+        "text": "49 Kay Street"
+      },
+      "expected": {
+        "properties": [
           {
             "street": "De Kay Street"
           }

--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -88,6 +88,7 @@
         "text": "450 37th st, new york, ny 11232"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
             "name": "450 37th Street",
@@ -104,11 +105,28 @@
             "label": "450 37th Street, Brooklyn, New York, NY, USA"
           }
         ]
+      }
+    },
+    {
+      "id": 3.1,
+      "status": "pass",
+      "isssue": "https://github.com/pelias/api/issues/456",
+      "description": "result with the wrong zipcode will be returned, but should have lower ranking than zipcoe match ",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "450 37th st, new york, ny 11232"
       },
-      "unexpected": {
+      "expected": {
         "properties": [
           {
-            "postalcode": "10018"
+            "name": "450 West 37th Street",
+            "country_a": "USA",
+            "region_a": "NY",
+            "locality": "New York",
+            "postalcode": "10018",
+            "housenumber": "450",
+            "street": "West 37th Street"
           }
         ]
       }

--- a/test_cases/australian_addresses.json
+++ b/test_cases/australian_addresses.json
@@ -26,7 +26,7 @@
     },
     {
       "id": 2,
-      "status": "fail",
+      "status": "pass",
       "in": {
         "text": "164 commercial rd, prahran, vic"
       },

--- a/test_cases/placeholder_altnames.json
+++ b/test_cases/placeholder_altnames.json
@@ -442,7 +442,7 @@
     },
     {
       "id": 19,
-      "status": "fail",
+      "status": "pass",
       "user": "lily",
       "endpoint": "reverse",
       "description": [

--- a/test_cases/tizen-sdk-geocoder.json
+++ b/test_cases/tizen-sdk-geocoder.json
@@ -1,6 +1,7 @@
 {
   "name": "tizen sdk: geocode",
   "priorityThresh": 1,
+  "distanceThresh": 50,
   "description": [
     "maps_service_geocode (const char *address): Gets the position coordinates for a given address",
     "maps_service_geocode_inside_area (const char *address, const maps_area_h bounds): Gets the position for a given address, within the specified bounding box",
@@ -87,9 +88,11 @@
       "expected": {
         "properties": [
           {
-            "name": "9 West 26th Street",
-            "distance": 0
+            "name": "9 West 26th Street"
           }
+        ],
+        "coordinates": [
+          [ -73.989231, 40.744022 ]
         ]
       }
     }

--- a/test_cases/wof_localadmins.json
+++ b/test_cases/wof_localadmins.json
@@ -1,10 +1,15 @@
 {
   "name": "Who's on First localadmins",
   "priorityThresh": 1,
+  "normalizers": {
+    "macroregion": [
+      "trim"
+    ]
+  },
   "tests": [
     {
       "id": 1,
-      "status": "fail",
+      "status": "pass",
       "user": "Stephen",
       "description": "chosen for diacriticals. space at the end of the name",
       "in": {


### PR DESCRIPTION
This is another round of updates to acceptance-tests to account for changes in Pelias behavior and data. See the individual commits for details.

One notable change is that the test now use the `trim` normalizer introduced in https://github.com/pelias/fuzzy-tester/pull/164, so the latest version of `pelias-fuzzy-tester` is now a requirement.