### PR TITLE
March updates

### DIFF
--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -90,7 +90,7 @@
     },
     {
       "id": "5",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/297",
       "description": "not sure it's an actual failure. needs discussion",
       "endpoint": "reverse",
@@ -102,7 +102,7 @@
       "expected": {
         "properties": [
           {
-            "region": "London"
+            "locality": "London"
           }
         ]
       },

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -123,9 +123,6 @@
         "properties": [
           {
             "label": "New York, NY, USA"
-          },
-          {
-            "label": "New York City, Manhattan, NY, USA"
           }
         ]
       }

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -295,7 +295,7 @@
       "status": "fail",
       "user": "missinglink",
       "notes": [ "from mapillary home page" ],
-      "description": "geonames result coming first",
+      "description": "geonames result coming first, not deduplicated due to diacritical",
       "issue": "https://github.com/pelias/pelias/issues/482",
       "in": {
         "text": "malmo"

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -212,6 +212,8 @@
         "priorityThresh": 1,
         "properties": [
           {
+            "name": "Wales",
+            "country": "United Kingdom",
             "label": "Wales, United Kingdom"
           }
         ]

--- a/test_cases/autocomplete_admin_areas.json
+++ b/test_cases/autocomplete_admin_areas.json
@@ -139,10 +139,16 @@
       "expected": {
         "properties": [
           {
-            "label": "London, Greater London, United Kingdom"
+            "name": "London",
+            "macroregion": "England",
+            "country": "United Kingdom",
+            "label": "London, England, United Kingdom"
           },
           {
-            "label": "London, Middlesex, Canada"
+            "name": "London",
+            "region": "Ontario",
+            "country": "Canada",
+            "label": "London, ON, Canada"
           }
         ]
       }

--- a/test_cases/deduplication.json
+++ b/test_cases/deduplication.json
@@ -44,8 +44,8 @@
           "name": "Pennsylvania",
           "layer": "region"
         }, {
-          "name": "Pennsylvania",
-          "layer": "neighbourhood",
+          "name": "Pennsylvania Township",
+          "layer": "localadmin",
           "region": "Illinois"
         }]
       }

--- a/test_cases/placeholder_general.json
+++ b/test_cases/placeholder_general.json
@@ -195,7 +195,7 @@
           {
             "gid": "whosonfirst:region:85684523",
             "confidence": 0.3,
-            "name": "County Durham"
+            "name": "Durham"
           }
         ]
       }
@@ -213,7 +213,7 @@
           {
             "gid": "whosonfirst:region:85684523",
             "confidence": 0.3,
-            "name": "County Durham"
+            "name": "Durham"
           }
         ]
       }

--- a/test_cases/placeholder_general.json
+++ b/test_cases/placeholder_general.json
@@ -238,9 +238,9 @@
     },
     {
       "id": 14,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
-      "description": "abbreviating periods should be removed",
+      "description": "abbreviating periods should be removed. Returns wildly incorrect result",
       "in": {
         "text": "L.A. C.A."
       },

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -735,11 +735,12 @@
       "id": 1500,
       "status": "pass",
       "endpoint": "search",
-      "description": "non-popular neighbourhoods should be found",
+      "description": "non-popular neighbourhoods should be found, don't have to be first",
       "in": {
         "text": "Getz"
       },
       "expected": {
+        "priorityThresh": 5,
         "properties": [
           {
             "gid": "whosonfirst:neighbourhood:85821441",

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -434,9 +434,12 @@
       "status": "fail",
       "endpoint": "search",
       "description": "borough should rank higher than county",
-      "issue": "https://github.com/pelias/placeholder/issues/55",
+      "issue": [
+        "https://github.com/pelias/placeholder/issues/55",
+        "https://github.com/whosonfirst-data/whosonfirst-data/issues/1555"
+      ],
       "in": {
-        "text": "Queens"
+        "text": "Queens, new york"
       },
       "expected": {
         "properties": [

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -529,7 +529,7 @@
         "properties": [
           {
             "gid": "whosonfirst:macrocounty:404227565",
-            "name": "Mittelfranken"
+            "name": "Middle Franconia"
           }
         ]
       }
@@ -699,7 +699,7 @@
         "properties": [
           {
             "gid": "whosonfirst:neighbourhood:85873785",
-            "name": "Les Halles"
+            "name": "Halles"
           }
         ]
       }

--- a/test_cases/reverse_coarse.json
+++ b/test_cases/reverse_coarse.json
@@ -89,10 +89,10 @@
       "expected": {
         "properties": [
           {
-            "layer": "localadmin",
+            "layer": "locality",
             "localadmin": "Saint-Ferreol-Des-Cotes",
             "county": "Ambert",
-            "macrocounty": "Ambert",
+            "macrocounty": "arrondissement of Ambert",
             "region": "Puy-de-Dôme",
             "macroregion": "Auvergne-Rhone-Alpes",
             "country": "France"
@@ -258,7 +258,7 @@
         "properties": [
           {
             "layer": "macrocounty",
-            "macrocounty": "Ambert",
+            "macrocounty": "arrondissement of Ambert",
             "region": "Puy-de-Dôme",
             "macroregion": "Auvergne-Rhone-Alpes",
             "country": "France"

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -530,7 +530,7 @@
       },
       "expected": {
         "properties": [{
-          "name": "Statue of Liberty",
+          "name": "Statue of Liberty replica",
           "country_a": "FRA",
           "region": "Paris"
         }]

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -308,7 +308,7 @@
     },
     {
       "id": "1425586777012:6",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/293",
       "description": "data issue",
       "user": "feedback-app",
@@ -319,13 +319,15 @@
       "expected": {
         "properties": [
           {
-            "label": "London, Greater London, United Kingdom"
+            "name": "London",
+            "country": "United Kingdom",
+            "label": "London, England, United Kingdom"
           },
           {
-            "label": "London, Middlesex, Canada"
-          },
-          {
-            "label": "London, United Kingdom"
+            "name": "London",
+            "region": "Ontario",
+            "country": "Canada",
+            "label": "London, ON, Canada"
           }
         ]
       }

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -1,5 +1,5 @@
 {
-  "name": "search",
+  "name": "search abbreviations",
   "priorityThresh": 5,
   "tests": [
     {

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -87,6 +87,27 @@
           }
         ]
       }
+    },
+    {
+      "id": 5,
+      "status": "fail",
+      "user": "julian",
+      "issue": "https://github.com/pelias/schema/issues/335",
+      "description": "Av abbreviation for Avenue",
+      "in": {
+        "text": "1320 E Edinger Ave, santa ana, CA"
+      },
+      "expected": {
+        "properties": [
+          {
+             "layer": "address",
+             "housenumber": "1320",
+             "street": "E Edinger Av",
+             "locality": "Santa Ana",
+             "region": "California"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -4,8 +4,9 @@
   "tests": [
     {
       "id": 1,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/737",
+      "description": "saint unabbreviated in data and query",
       "user": "julian",
       "in": {
         "text": "412 Saint Patrick St, donaldsonville, la"
@@ -15,7 +16,7 @@
           {
              "layer": "address",
              "housenumber": "412",
-             "street": "St Patrick St",
+             "street": "Saint Patrick Street",
              "locality": "Donaldsonville",
              "region": "Louisiana"
           }
@@ -26,6 +27,7 @@
       "id": 2,
       "status": "pass",
       "user": "julian",
+      "description": "saint unabbreviated in data, abbreviated in query",
       "in": {
         "text": "412 St Patrick St, donaldsonville, la"
       },
@@ -34,7 +36,7 @@
           {
              "layer": "address",
              "housenumber": "412",
-             "street": "St Patrick St",
+             "street": "Saint Patrick Street",
              "locality": "Donaldsonville",
              "region": "Louisiana"
           }

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -25,8 +25,9 @@
     },
     {
       "id": 2,
-      "status": "pass",
+      "status": "fail",
       "user": "julian",
+      "issue": "https://github.com/pelias/pelias/issues/737",
       "description": "saint unabbreviated in data, abbreviated in query",
       "in": {
         "text": "412 St Patrick St, donaldsonville, la"
@@ -39,6 +40,50 @@
              "street": "Saint Patrick Street",
              "locality": "Donaldsonville",
              "region": "Louisiana"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "julian",
+      "issue": "https://github.com/pelias/pelias/issues/737",
+      "description": "saint abbreviated in data, abbreviated in query",
+      "in": {
+        "text": "3929 St Marks Avenue, Niagara Falls, ON, Canada"
+      },
+      "expected": {
+        "properties": [
+          {
+             "layer": "address",
+             "housenumber": "3929",
+             "street": "St Marks Avenue",
+             "locality": "Niagara Falls",
+             "region": "Ontario",
+             "country": "Canada"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "status": "fail",
+      "user": "julian",
+      "issue": "https://github.com/pelias/pelias/issues/737",
+      "description": "saint abbreviated in data, unabbreviated in query",
+      "in": {
+        "text": "3929 Siant Marks Avenue, Niagara Falls, ON, Canada"
+      },
+      "expected": {
+        "properties": [
+          {
+             "layer": "address",
+             "housenumber": "3929",
+             "street": "St Marks Avenue",
+             "locality": "Niagara Falls",
+             "region": "Ontario",
+             "country": "Canada"
           }
         ]
       }

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -1208,7 +1208,7 @@
     },
     {
       "id": 1202,
-      "status": "fail",
+      "status": "pass",
       "user": "julian",
       "notes": "saint should be handled when not-abbreviated in address searches",
       "issue": "https://github.com/pelias/pelias/issues/737",
@@ -1221,7 +1221,7 @@
           {
             "layer": "address",
             "housenumber": "412",
-            "street": "St Patrick St",
+            "street": "Saint Patrick Street",
             "locality": "Donaldsonville",
             "region": "Louisiana"
           }

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -463,10 +463,10 @@
         "properties": [
           {
             "layer": "localadmin",
-            "name": "Zickrick",
+            "name": "Zickrick Township",
             "country_a": "USA",
             "country": "United States",
-            "localadmin": "Zickrick"
+            "localadmin": "Zickrick Township"
           }
         ]
       }
@@ -485,10 +485,10 @@
         "properties": [
           {
             "layer": "localadmin",
-            "name": "Zumbehl",
+            "name": "Zumbehl Township",
             "country_a": "USA",
             "country": "United States",
-            "localadmin": "Zumbehl"
+            "localadmin": "Zumbehl Township"
           }
         ]
       }
@@ -508,12 +508,12 @@
         "properties": [
           {
             "layer": "localadmin",
-            "name": "Aastad",
+            "name": "Aastad Township",
             "country_a": "USA",
             "country": "United States",
             "region_a": "MN",
             "region": "Minnesota",
-            "localadmin": "Aastad"
+            "localadmin": "Aastad Township"
           }
         ]
       }
@@ -526,19 +526,19 @@
       "notes": "unambiguous localadmin by state",
       "in": {
         "sources": "wof",
-        "locality": "Bloominggrove",
+        "locality": "Bloominggrove Township",
         "region": "Ohio"
       },
       "expected": {
         "properties": [
           {
             "layer": "localadmin",
-            "name": "Bloominggrove",
+            "name": "Bloominggrove Township",
             "country_a": "USA",
             "country": "United States",
             "region_a": "OH",
             "region": "Ohio",
-            "localadmin": "Bloominggrove"
+            "localadmin": "Bloominggrove Township"
           }
         ]
       }
@@ -658,10 +658,10 @@
         "properties": [
           {
             "layer": "macrocounty",
-            "name": "Gießen",
+            "name": "Giessen Government Region",
             "country_a": "DEU",
             "country": "Germany",
-            "macrocounty": "Gießen"
+            "macrocounty": "Giessen Government Region"
           }
         ]
       }
@@ -680,10 +680,10 @@
         "properties": [
           {
             "layer": "macrocounty",
-            "name": "Mittelfranken",
+            "name": "Middle Franconia",
             "country_a": "DEU",
             "country": "Germany",
-            "macrocounty": "Mittelfranken"
+            "macrocounty": "Middle Franconia"
           }
         ]
       }
@@ -701,10 +701,10 @@
         "properties": [
           {
             "layer": "macrocounty",
-            "name": "Arnsberg",
+            "name": "Arnsberg Government Region",
             "country_a": "DEU",
             "country": "Germany",
-            "macrocounty": "Arnsberg"
+            "macrocounty": "Arnsberg Government Region"
           }
         ]
       }

--- a/test_cases/tizen-sdk-places.json
+++ b/test_cases/tizen-sdk-places.json
@@ -47,7 +47,7 @@
         "properties": [
           {
             "name": "Wells Fargo",
-            "localadmin": "Newtown",
+            "localadmin": "Newtown Township",
             "region_a": "PA"
           }
         ]
@@ -96,7 +96,7 @@
         "properties": [
           {
             "name": "Wells Fargo",
-            "localadmin": "Newtown",
+            "localadmin": "Newtown Township",
             "region_a": "PA"
           }
         ]

--- a/test_cases/university.json
+++ b/test_cases/university.json
@@ -206,7 +206,7 @@
         "properties": [
           {
             "name": "Ohio State University Lima",
-            "localadmin": "Bath"
+            "localadmin": "Bath Township"
           }
         ]
       }

--- a/test_cases/wof_counties.json
+++ b/test_cases/wof_counties.json
@@ -19,8 +19,8 @@
         "properties": [
           {
             "layer": "county",
-            "name": "Potter",
-            "county": "Potter",
+            "name": "Potter County",
+            "county": "Potter County",
             "region": "Pennsylvania",
             "region_a": "PA",
             "country": "United States",
@@ -65,10 +65,10 @@
         "priorityThresh": 2,
         "properties": [
           {
-            "layer": "localadmin",
+            "layer": "locality",
             "name": "Arzacq-Arraziguet",
             "county": "Arzacq-Arraziguet",
-            "macrocounty": "Pau",
+            "macrocounty": "arrondissement of Pau",
             "region": "Pyrénées-Atlantiques",
             "macroregion": "New Aquitaine",
             "country": "France",

--- a/test_cases/wof_localadmins.json
+++ b/test_cases/wof_localadmins.json
@@ -66,7 +66,7 @@
         "properties": [
           {
             "layer": "localadmin",
-            "name": "Zickrick",
+            "name": "Zickrick Township",
             "region": "South Dakota",
             "region_a": "SD",
             "country": "United States",

--- a/test_cases/wof_localities.json
+++ b/test_cases/wof_localities.json
@@ -158,22 +158,20 @@
     },
     {
       "id": 8,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/acceptance-tests/issues/213",
       "description": "returns the right result second, cause unknown",
       "user": "Stephen",
       "in": {
-        "text": "San Jaun, Puerto Rico",
+        "text": "San Juan, Puerto Rico",
         "sources": "wof"
       },
       "expected": {
         "properties": [
           {
             "locality": "San Juan",
-            "region": "Puerto Rico",
-            "region_a": "PRI",
-            "country": "United States",
-            "country_a": "USA",
+            "dependency": "Puerto Rico",
+            "dependency_a": "PRI",
             "name": "San Juan"
           }
         ]

--- a/test_cases/wof_macroregions.json
+++ b/test_cases/wof_macroregions.json
@@ -36,8 +36,8 @@
         "properties": [
           {
             "layer": "macroregion",
-            "name": "Navarra",
-            "macroregion": "Navarra",
+            "name": "Navarre",
+            "macroregion": "Navarre",
             "country": "Spain",
             "country_a": "ESP"
           }

--- a/test_cases/wof_neighbourhoods.json
+++ b/test_cases/wof_neighbourhoods.json
@@ -79,7 +79,7 @@
           {
             "layer": "neighbourhood",
             "name": "Gaddiannaram",
-            "locality": "Hyderabad",
+            "county": "Hyderabad",
             "region": "Andhra Pradesh",
             "country": "India",
             "country_a": "IND"

--- a/test_cases/wof_regions.json
+++ b/test_cases/wof_regions.json
@@ -164,8 +164,8 @@
         "properties": [
           {
             "layer": "region",
-            "name": "Xaçmaz",
-            "region": "Xaçmaz",
+            "name": "Xacmaz",
+            "region": "Xacmaz",
             "country": "Azerbaijan",
             "country_a": "AZE"
           }
@@ -186,9 +186,9 @@
           {
             "gid": "whosonfirst:region:85670011",
             "layer": "region",
-            "name": "Kasaï-Oriental",
-            "region": "Kasaï-Oriental",
-            "country": "Democratic Republic of the Congo",
+            "name": "Kasaï-Occidental Province",
+            "region": "Kasaï-Occidental Province",
+            "country": "Democratic Republic of Congo",
             "country_a": "COD"
           }
         ]


### PR DESCRIPTION
This PR started out as an update to improve the acceptance test results based on more up to date data in Placeholder (the dataset we generally ran them against is a few months old), but it's expanded to include numerous other fixes.

Labels for London and New York were re-evaluated, and many abbreviation related tests were added or improved, to correspond with work in https://github.com/pelias/schema/pull/356 andhttps://github.com/pelias/schema/pull/355 