### PR TITLE
Mark tests failing with ES5

### DIFF
--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -136,7 +136,7 @@
     },
     {
       "id": 10,
-      "status": "pass",
+      "status": "fail",
       "user": "missinglink",
       "in": {
         "text": "Hackney City Farm, Haggerston, Greater London"

--- a/test_cases/result_properties.json
+++ b/test_cases/result_properties.json
@@ -4,7 +4,7 @@
   "tests": [
     {
       "id": 1,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
       "description": "test it in search results and OSM data",
       "in": {

--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "id": "searchpoi-1",
-      "status": "pass",
+      "status": "fail",
       "description": "@nvkelso couldn't find Target in Eureka while visiting home",
       "issue": "https://github.com/pelias/pelias/issues/185",
       "user": "riordan",
@@ -26,7 +26,7 @@
     },
     {
       "id": "searchpoi-2",
-      "status": "pass",
+      "status": "fail",
       "description": "@nvkelso couldn't find Target in Eureka while visiting home",
       "issue": "https://github.com/pelias/pelias/issues/185",
       "user": "riordan",

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -290,10 +290,10 @@
 
     {
       "id": 200,
-      "status": "pass",
+      "status": "fail",
       "user": "trescube",
       "type": "dev",
-      "notes": "exercises treating locality as borough when latter not explicitly supplied",
+      "notes": "exercises treating locality as borough when latter not explicitly supplied. Manhattan, NY population should rank it higher than it is",
       "in": {
         "locality": "Manhattan"
       },


### PR DESCRIPTION
They all seem to be connected to popularity or focus points.

Perhaps related to https://github.com/pelias/api/issues/1205