### PR TITLE
Use correct address format globally

### DIFF
--- a/test_cases/international.json
+++ b/test_cases/international.json
@@ -40,7 +40,7 @@
       "expected": {
         "properties": [
           {
-            "name": "500 Rua Henri Dunant",
+            "name": "Rua Henri Dunant 500",
             "locality": "São Paulo",
             "country_a": "BRA"
           }
@@ -112,7 +112,7 @@
       "expected": {
         "properties": [
           {
-            "name": "121 via Vittorio Veneto",
+            "name": "via Vittorio Veneto 121",
             "locality": "Rome",
             "country_a": "ITA"
           }

--- a/test_cases/locality_geodisambiguation.json
+++ b/test_cases/locality_geodisambiguation.json
@@ -17,7 +17,7 @@
         "properties": [
           {
             "layer": "address",
-            "name": "83 Bichlachweg",
+            "name": "Bichlachweg 83",
             "county": "Kitzbühel"
           }
         ]
@@ -37,7 +37,7 @@
         "properties": [
           {
             "layer": "address",
-            "name": "83 Bichlachweg",
+            "name": "Bichlachweg 83",
             "county": "Kitzbühel"
           }
         ]
@@ -45,4 +45,3 @@
     }
   ]
 }
-    


### PR DESCRIPTION
Thanks to https://github.com/pelias/api/pull/1344 we hopefully now have
a definitive list of countries where the housenumber comes after the
street name.

This commit updates our acceptance tests accordingly