### PR TITLE
Add tests for addresses with hyphens

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -363,6 +363,48 @@
           }
         ]
       }
+    },
+    {
+      "id": 11,
+      "status": "pass",
+      "issue": "https://github.com/pelias/schema/issues/65",
+      "user": "julian",
+      "in": {
+        "text": "Friedrich-Richter-Straße 51"
+      },
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "51",
+            "street": "Friedrich-Richter-Straße",
+            "confidence": 1,
+            "match_type": "exact",
+            "accuracy": "point",
+            "locality": "Berlin"
+          }
+        ]
+      }
+    },
+    {
+      "id": "11.1",
+      "status": "pass",
+      "issue": "https://github.com/pelias/schema/issues/65",
+      "user": "julian",
+      "in": {
+        "text": "Friedrich Richter Straße 51"
+      },
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "51",
+            "street": "Friedrich-Richter-Straße",
+            "confidence": 1,
+            "match_type": "exact",
+            "accuracy": "point",
+            "locality": "Berlin"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/french_addresses.json
+++ b/test_cases/french_addresses.json
@@ -47,6 +47,25 @@
       }
     },
     {
+      "id": "2-no-hyphen",
+      "status": "pass",
+      "user": "adefarge",
+      "type": "france",
+      "in": {
+        "text": "20 Boulevard Saint Martin, Paris"
+      },
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "20",
+            "street": "Boulevard Saint-martin",
+            "locality": "Paris",
+            "country_a": "FRA"
+          }
+        ]
+      }
+    },
+    {
       "id": "2-abbrev",
       "status": "fail",
       "user": "adefarge",
@@ -300,6 +319,27 @@
             "housenumber": "40",
             "street": "Rue De L'arsenal",
             "locality": "Bordeaux",
+            "country_a": "FRA"
+          }
+        ]
+      }
+    },
+    {
+      "id": "11",
+      "status": "pass",
+      "user": "orangejulius",
+      "type": "france",
+      "description": "address without hyphens",
+      "issue": "https://github.com/pelias/api/pull/1268",
+      "in": {
+        "text": "20 boulevard saint germain, paris, france"
+      },
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "20",
+            "street": "Boulevard Saint-Germain",
+            "locality": "Paris",
             "country_a": "FRA"
           }
         ]


### PR DESCRIPTION
This is mainly tests that are now passing with pelias/schema#375!! :tada: 

Connects https://github.com/pelias/schema/issues/301
Connects https://github.com/pelias/schema/pull/375
Connects https://github.com/pelias/schema/issues/65

@Joxit if you know of any more that should definitely be added, let us know
