### PR TITLE
Add tests for Phoenix Airport

### DIFF
--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -203,6 +203,78 @@
           "country": "Spain"
         }]
       }
+    },
+    {
+      "id": 9,
+      "status": "fail",
+      "description": "search for Phoenix Intl airport with focus point in Phoenix",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "Phoenix International Airport",
+        "focus.point.lat": 33.44155,
+        "focus.point.lon": -112.09721
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [  -112.012869, 33.434743 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Phoenix Sky Harbor International Airport",
+          "locality": "Phoenix",
+          "region_a": "AZ",
+          "country_a": "USA"
+        }]
+      }
+    },
+    {
+      "id": 9.1,
+      "status": "fail",
+      "description": "search for Phoenix Intl airport with focus point in Phoenix",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "Phoenix Airport",
+        "focus.point.lat": 33.44155,
+        "focus.point.lon": -112.09721
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [  -112.012869, 33.434743 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Phoenix Sky Harbor International Airport",
+          "locality": "Phoenix",
+          "region_a": "AZ",
+          "country_a": "USA"
+        }]
+      }
+    },
+    {
+      "id": 9.2,
+      "status": "fail",
+      "description": "search for Phoenix Intl airport with focus point in Phoenix",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "Phoenix sky harbor",
+        "focus.point.lat": 33.44155,
+        "focus.point.lon": -112.09721
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [  -112.012869, 33.434743 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Phoenix Sky Harbor International Airport",
+          "locality": "Phoenix",
+          "region_a": "AZ",
+          "country_a": "USA"
+        }]
+      }
     }
   ]
 }


### PR DESCRIPTION
This is a good test of POI ranking since there are many similarly named POIs: bus stops, rental cars, etc. There is also a smaller but well known airport elsewhere in Phoenix. The international airport _should_ be ranked higher than all those.

Finally, the official airport name is not commonly searched exactly (people leave out "sky harbor"), further testing our alt name and matching abilities. 

Related issues: 

https://github.com/pelias/pelias/issues/260
https://github.com/pelias/pelias/issues/862
