### PR TITLE
Add missing expectation that test will fail

### DIFF
--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -504,6 +504,7 @@
     {
       "id": 20,
       "user": "orangejulius",
+      "status": "fail",
       "in": {
         "text": "statue of liberty",
         "boundary.country": "USA"


### PR DESCRIPTION
After https://github.com/pelias/fuzzy-tester/pull/192, test cases without a `status` will be assumed to _pass_. It turns out we had a test that was failing.

This change updates that expectation so the test suite behavior stays the same.