### PR TITLE
Increase strictness of balance tests

### DIFF
--- a/test_cases/balance.json
+++ b/test_cases/balance.json
@@ -1,6 +1,6 @@
 {
   "name": "poi vs. admin areas balance",
-  "priorityThresh": 5,
+  "priorityThresh": 1,
   "endpoint": "search",
   "tests": [
     {

--- a/test_cases/balance.json
+++ b/test_cases/balance.json
@@ -32,9 +32,13 @@
     },
     {
       "id": 2,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
-      "issue": "https://github.com/pelias/api/issues/346",
+      "issue": [
+        "https://github.com/pelias/api/issues/346",
+        "https://github.com/pelias/openstreetmap/issues/507",
+        "https://github.com/pelias/pelias/issues/849"
+      ],
       "description": [
         "When focus point is specified, results should slightly favor",
         "nearby POIs, while still surfacing larger regions further away"


### PR DESCRIPTION
I was wondering why no tests alerted us of the focus point balance issues in https://github.com/pelias/pelias/issues/849 and https://github.com/pelias/openstreetmap/issues/507.

It turned out that the `priorityThresh` value in the relevant tests was too generous.

This is now changed and we should be able to tell if/when progress is made.
