### PR TITLE
Improve Statue of Liberty test

### DIFF
--- a/test_cases/landmarks.json
+++ b/test_cases/landmarks.json
@@ -20,9 +20,13 @@
         "text": "statue of liberty"
       },
       "expected": {
+        "priorityThresh": 1,
         "properties": [
           {
-            "label": "Statue of Liberty, Manhattan, NY, USA"
+            "name": "Statue of Liberty",
+            "locality": "New York",
+            "country_a": "USA",
+            "label": "Statue of Liberty, Manhattan, New York, NY, USA"
           }
         ]
       }


### PR DESCRIPTION
This test has had an incorrect label, last updated in 2016, so it was showing as failed even when it is actually much improved with venue popularity changes.