### PR TITLE
Use abbreviation normalizer in autocomplete jitter tests

### DIFF
--- a/test_cases/autocomplete_jitter.json
+++ b/test_cases/autocomplete_jitter.json
@@ -2,6 +2,14 @@
   "name": "autocomplete jitter",
   "priorityThresh": 5,
   "endpoint": "autocomplete",
+  "normalizers": {
+    "street": [
+      "toUpperCase",
+      "abbreviateDirectionals",
+      "abbreviateStreetSuffixes",
+      "toLowerCase"
+    ]
+  },
   "tests": [
     {
       "id": "1.1",


### PR DESCRIPTION
This handles minor differences in the order of records with `st` vs `street` in the results.