### PR TITLE
Add search test case for 'Mt/Mount' in a _venue_ name

### DIFF
--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -244,6 +244,25 @@
       }
     },
     {
+      "id": 8.3,
+      "status": "fail",
+      "user": "julian",
+      "in": {
+        "text": "Mt Tabor Park, Portland, OR"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Mount Tabor Park",
+            "layer": "venue",
+            "locality": "Portland",
+            "region_a": "OR",
+            "country_a": "USA"
+          }
+        ]
+      }
+    },
+    {
       "id": 9,
       "status": "fail",
       "user": "missinglink",


### PR DESCRIPTION
This uses different fields and synonyms from the corresponding autocomplete test, so should be tested separately. We don't appear to get it right currently

Connects https://github.com/OpenTransitTools/trimet-mod-pelias/issues/27