### PR TITLE
Mark tests passing from synyonm overhaul

### DIFF
--- a/test_cases/autocomplete_abbreviations.json
+++ b/test_cases/autocomplete_abbreviations.json
@@ -69,7 +69,7 @@
     },
     {
       "id": 4,
-      "status": "fail",
+      "status": "pass",
       "user": "julian",
       "issue": "https://github.com/pelias/pelias/issues/737",
       "description": "saint abbreviated in data, unabbreviated in query",

--- a/test_cases/french_addresses.json
+++ b/test_cases/french_addresses.json
@@ -87,7 +87,7 @@
     },
     {
       "id": "2-abbrev",
-      "status": "fail",
+      "status": "pass",
       "user": "adefarge",
       "type": "france",
       "description": "Missing synonyms",

--- a/test_cases/international.json
+++ b/test_cases/international.json
@@ -197,7 +197,7 @@
     },
     {
       "id": 10,
-      "status": "fail",
+      "status": "pass",
       "user": "Lily",
       "type": "dev",
       "issue": "https://github.com/pelias/api/issues/783",

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -25,7 +25,7 @@
     },
     {
       "id": 1.1,
-      "status": "fail",
+      "status": "pass",
       "user": "julian",
       "issue": "https://github.com/pelias/pelias/issues/737",
       "description": "saint unabbreviated in data, abbreviated in query",
@@ -96,7 +96,7 @@
     },
     {
       "id": 4,
-      "status": "fail",
+      "status": "pass",
       "user": "julian",
       "issue": "https://github.com/pelias/pelias/issues/737",
       "description": "saint abbreviated in data, unabbreviated in query",
@@ -169,7 +169,7 @@
     },
     {
       "id": 7.1,
-      "status": "fail",
+      "status": "pass",
       "user": "missinglink",
       "notes": ["Av. == Avenida"],
       "in": {
@@ -215,7 +215,7 @@
     },
     {
       "id": 8.1,
-      "status": "fail",
+      "status": "pass",
       "user": "missinglink",
       "in": {
         "text": "W Mt Hope Av. MI USA"
@@ -264,7 +264,7 @@
     },
     {
       "id": 9,
-      "status": "fail",
+      "status": "pass",
       "user": "missinglink",
       "in": {
         "text": "E 98th Ter, MO, USA"

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -141,6 +141,7 @@
       "id": 6.1,
       "status": "fail",
       "user": "missinglink",
+      "issue": "https://github.com/pelias/schema/issues/301",
       "notes": ["R == Rue"],
       "in": {
         "text": "R Gay Lussac, Paris"


### PR DESCRIPTION
In https://github.com/pelias/schema/pull/453 we have some major improvements to the Pelias synonym system used to handle most abbreviations.

As a result of that work, 9 acceptance tests are now passing. This PR marks those as testing and if they represent a particular github issue that is clearly now resolved, marks that issue as fixed.

Some overall issues like https://github.com/pelias/api/issues/783 and https://github.com/pelias/schema/issues/301 for Spanish and French addresses are not marked as fixed, but we should go through the discussions there to see if they've effectively been resolved.