### PR TITLE
Add fallback test case

### DIFF
--- a/test_cases/fallback.json
+++ b/test_cases/fallback.json
@@ -73,6 +73,36 @@
           }
         ]
       }
+    },
+    {
+      "id": 4,
+      "status": "pass",
+      "user": "julian",
+      "description": "query for a nonexistent street in a city returns that city, rather than instances of that street in other cities",
+      "in": {
+        "text": "california avenue, berlin, germany"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Berlin",
+            "layer": "locality",
+            "country_a": "DEU",
+            "locality": "Berlin",
+            "match_type": "fallback"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "layer": "street"
+          },
+          {
+            "name": "California Avenue"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Fallback behavior is a core part of Pelias: rather than just returning any results that match some of the search terms, we want Pelias to return results with some knowledge of the hierarchy of elements in the query.

This adds a test case confirming the behavior that, when given a query for a street in a city, but the street doesn't exist Pelias returns the city.

The undesired behavior is that other streets with the same name in other cities are returned.

Here's an example of the correct behavior:
![Screenshot_2020-07-07_14-22-00](https://user-images.githubusercontent.com/111716/86844681-40ceaf00-c05d-11ea-928a-6c66415998be.png)
