### PR TITLE
Update tests for NYC Labels

### DIFF
--- a/test_cases/address_matching.json
+++ b/test_cases/address_matching.json
@@ -126,7 +126,7 @@
       "expected": {
         "priorityThresh": 2,
         "properties": [
-          { "label": "190 Dean Street, Brooklyn, New York, NY, USA" }
+          { "label": "190 Dean Street, Brooklyn, NY, USA" }
         ]
       }
     },

--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -26,7 +26,7 @@
             "postalcode": "10009",
             "housenumber": "101",
             "street": "Saint Marks Place",
-            "label": "101 Saint Marks Place, Manhattan, New York, NY, USA"
+            "label": "101 Saint Marks Place, New York, NY, USA"
           }
         ]
       }
@@ -102,7 +102,7 @@
             "postalcode": "11232",
             "housenumber": "450",
             "street": "37th Street",
-            "label": "450 37th Street, Brooklyn, New York, NY, USA"
+            "label": "450 37th Street, Brooklyn, NY, USA"
           }
         ]
       }
@@ -178,7 +178,7 @@
             "postalcode": "11232",
             "housenumber": "455",
             "street": "43rd Street",
-            "label": "455 43rd Street, Brooklyn, New York, NY, USA"
+            "label": "455 43rd Street, Brooklyn, NY, USA"
           }
         ]
       }
@@ -206,7 +206,7 @@
             "postalcode": "11201",
             "housenumber": "1",
             "street": "Main Street",
-            "label": "1 Main Street, Brooklyn, New York, NY, USA"
+            "label": "1 Main Street, Brooklyn, NY, USA"
           }
         ]
       }

--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -150,7 +150,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Crown Heights, Brooklyn, New York, NY, USA",
+            "label": "Crown Heights, Brooklyn, NY, USA",
             "name": "Crown Heights",
             "country_a": "USA",
             "country": "United States",

--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -16,7 +16,7 @@
       "expected": {
         "properties": [
           {
-            "label": "DiDi Dumpling, Manhattan, New York, NY, USA"
+            "label": "DiDi Dumpling, New York, NY, USA"
           }
         ]
       }
@@ -96,7 +96,7 @@
         "priorityThresh": 1,
         "properties": [
           {
-            "label": "Hard Rock Cafe, Manhattan, New York, NY, USA"
+            "label": "Hard Rock Cafe, New York, NY, USA"
           }
         ]
       }

--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -443,7 +443,7 @@
       "expected": {
         "priorityThresh": 2,
         "properties": [
-          { "label": "190 Dean Street, Brooklyn, New York, NY, USA" }
+          { "label": "190 Dean Street, Brooklyn, NY, USA" }
         ]
       }
     }

--- a/test_cases/autocomplete_venues.json
+++ b/test_cases/autocomplete_venues.json
@@ -14,7 +14,10 @@
       "expected": {
         "properties": [
           {
-            "label": "DiDi Dumpling, Manhattan, New York, NY, USA"
+            "name": "DiDi Dumpling",
+            "borough": "Manhattan",
+            "region_a": "NY",
+            "country_a": "USA"
           }
         ]
       }

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -25,7 +25,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "30 West 26th Street, Manhattan, New York, NY, USA"
+          "label": "30 West 26th Street, New York, NY, USA"
         }]
       }
     },

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -392,6 +392,40 @@
           }
         ]
       }
+    },
+    {
+      "id": 25,
+      "status": "pass",
+      "description": "Queens address should use neighbourhood name in label",
+      "issue": "https://github.com/pelias/labels/pull/39",
+      "user": "julian",
+      "in": {
+        "text": "38-04 Broadway, Astoria, NY 11103"
+      },
+      "expected": {
+        "properties": [
+          {
+            "label": "38-04 Broadway, Astoria, NY, USA"
+          }
+        ]
+      }
+    },
+    {
+      "id": 26,
+      "status": "pass",
+      "description": "Manhattan neighbourhood",
+      "issue": "https://github.com/pelias/labels/pull/39",
+      "user": "julian",
+      "in": {
+        "text": "East Village, nyc"
+      },
+      "expected": {
+        "properties": [
+          {
+            "label": "East Village, Manhattan, New York, NY, USA"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -13,7 +13,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Brooklyn, New York, NY, USA"
+            "label": "Brooklyn, NY, USA"
           }
         ]
       }
@@ -29,7 +29,7 @@
       "expected": {
         "properties": [
           {
-            "label": "Brooklyn, New York, NY, USA"
+            "label": "Brooklyn, NY, USA"
           }
         ]
       }

--- a/test_cases/search_coarse.json
+++ b/test_cases/search_coarse.json
@@ -16,7 +16,12 @@
       "expected": {
         "properties": [
           {
-            "label": "Brooklyn, New York, NY, USA"
+            "name": "Brooklyn",
+            "layer": "borough",
+            "locality": "New York",
+            "region_a": "NY",
+            "country_a": "USA",
+            "label": "Brooklyn, NY, USA"
           }
         ]
       }


### PR DESCRIPTION
Over in https://github.com/pelias/labels/pull/39 we have completely redone the labels for New York City, and they should be essentially 100% correct now, with all the special cases handled.

This PR updates all the acceptance tests for those new labels, and also adds some additional label tests to make sure we continue to get all the really interesting special cases, especially those in Queens, correct going forward.