### PR TITLE
Add test for multi-word input in non-default language

### DIFF
--- a/test_cases/autocomplete_multi_lang.json
+++ b/test_cases/autocomplete_multi_lang.json
@@ -230,6 +230,26 @@
           }
         ]
       }
+    },
+    {
+      "id": "8-1",
+      "status": "pass",
+      "user": "Joxit",
+      "issue": "https://github.com/pelias/api/issues/1296",
+      "in": {
+        "lang": "en",
+        "layers": "venue",
+        "text": "Edo Tokyo Museum"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "venue",
+            "country": "Japan",
+            "name": "Edo Tokyo Museum"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds a test for finding [Edo Tokyo Museum](https://pelias.github.io/compare/#/v1/autocomplete?layers=venue&debug=1&text=Edo+Tokyo+Museum) via autocomplete.

Connects https://github.com/pelias/api/issues/1296#issuecomment-703679827
Connects https://github.com/pelias/api/pull/1493