### PR TITLE
Adjust street suffixes for new normalization

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -302,7 +302,7 @@
       "expected": {
         "properties": [
           {
-            "name": "3577 Jackson St",
+            "name": "3577 Jackson Street",
             "country_a": "USA",
             "country": "United States",
             "region": "California",
@@ -311,8 +311,8 @@
             "locality": "San Francisco",
             "postalcode": "94118",
             "housenumber": "3577",
-            "street": "Jackson St",
-            "label": "3577 Jackson St, San Francisco, CA, USA"
+            "street": "Jackson Street",
+            "label": "3577 Jackson Street, San Francisco, CA, USA"
           }
         ]
       }
@@ -419,7 +419,7 @@
         "properties": [
           {
             "housenumber": "23",
-            "street": "Huckleberry Hl",
+            "street": "Huckleberry Hill",
             "confidence": 1,
             "match_type": "exact",
             "accuracy": "point",

--- a/test_cases/admin_lookup.json
+++ b/test_cases/admin_lookup.json
@@ -478,7 +478,7 @@
           {
             "layer": "address",
             "housenumber": "5",
-            "street": "W 4th Ave",
+            "street": "West 4th Avenue",
             "country_a": "CAN",
             "country": "Canada",
             "locality": "Vancouver"

--- a/test_cases/admin_translations.json
+++ b/test_cases/admin_translations.json
@@ -164,7 +164,7 @@
         "lang: polish"
       ],
       "in": {
-        "address": "285 Fulton St",
+        "address": "285 Fulton Street",
         "borough": "Manhattan",
         "locality": "New York",
         "region": "NY",

--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -142,14 +142,6 @@
             "region": "New York",
             "borough": "Manhattan",
             "locality": "New York"
-          },
-          {
-            "layer": "address",
-            "housenumber": "1",
-            "street": "Madison Ave",
-            "region": "New York",
-            "borough": "Manhattan",
-            "locality": "New York"
           }
         ]
       }

--- a/test_cases/confidence_score.json
+++ b/test_cases/confidence_score.json
@@ -14,9 +14,9 @@
       "expected": {
         "properties": [
           {
-            "name": "1 W 72 St",
+            "name": "1 West 72 Street",
             "housenumber": "1",
-            "street": "W 72 St",
+            "street": "West 72 Street",
             "country_a": "USA",
             "postalcode": "10023",
             "confidence": 1

--- a/test_cases/exact_matches.json
+++ b/test_cases/exact_matches.json
@@ -126,10 +126,6 @@
           {
             "name": "518 3rd Street",
             "locality": "New York"
-          },
-          {
-            "name": "518 3 St",
-            "locality": "New York"
           }
         ]
       }

--- a/test_cases/placeholder_geometric_filters.json
+++ b/test_cases/placeholder_geometric_filters.json
@@ -37,7 +37,7 @@
       "expected": {
         "properties": [
           {
-            "name": "2000 Main St",
+            "name": "2000 Main Street",
             "country_a": "CAN"
           }
         ]

--- a/test_cases/search_abbreviations.json
+++ b/test_cases/search_abbreviations.json
@@ -130,7 +130,7 @@
           {
              "layer": "address",
              "housenumber": "1320",
-             "street": "E Edinger Av",
+             "street": "East Edinger Avenue",
              "locality": "Santa Ana",
              "region": "California"
           }

--- a/test_cases/search_iso2_to_iso3.json
+++ b/test_cases/search_iso2_to_iso3.json
@@ -83,7 +83,7 @@
             "layer": "address",
             "country_a": "CAN",
             "locality": "Toronto",
-            "street": "Lloyd George Ave",
+            "street": "Lloyd George Avenue",
             "housenumber": "22"
           }
         ]

--- a/test_cases/search_postal_cities.json
+++ b/test_cases/search_postal_cities.json
@@ -85,7 +85,7 @@
       "expected": {
         "properties": [{
           "housenumber": "15364",
-          "street": "Kensington Park Dr",
+          "street": "Kensington Park Drive",
           "layer": "address",
           "locality": "Woodbridge",
           "region_a": "VA",

--- a/test_cases/search_street_centroids.json
+++ b/test_cases/search_street_centroids.json
@@ -156,7 +156,7 @@
         "properties": [
           {
             "housenumber": "621",
-            "street": "SE Martin Luther King Jr Blvd",
+            "street": "SE Martin Luther King Jr Boulevard",
             "locality": "Portland",
             "region_a": "OR",
             "country_a": "USA"

--- a/test_cases/tizen-sdk-geocoder.json
+++ b/test_cases/tizen-sdk-geocoder.json
@@ -43,7 +43,7 @@
       "expected": {
         "properties": [
           {
-            "name": "30 W 26th St",
+            "name": "30 West 26th Street",
             "region_a": "PA"
           }
         ]


### PR DESCRIPTION
Thanks to https://github.com/pelias/openaddresses/pull/477 we have improved street name normalization for many common suffixes.

This change updates our acceptance tests based on those changes. There are quite a few changes, and they're all pretty positive. While hard to tell from the acceptance tests themselves, they generally come along with reduced duplicate results
