### PR TITLE
Add tests for 2 letter country code handling in autocomplete

### DIFF
--- a/test_cases/autocomplete_iso2_to_iso3.json
+++ b/test_cases/autocomplete_iso2_to_iso3.json
@@ -1,0 +1,122 @@
+{
+  "name": "ISO2->ISO3 internal conversion",
+  "notes": "Ensure both 2 and 3 letter country codes are handled in autocomplete",
+  "priorityThresh": 1,
+  "endpoint": "autocomplete",
+  "tests": [
+    {
+      "id": 1,
+      "status": "fail",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "mexico city, mx"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "locality",
+            "country_a": "MEX",
+            "locality": "Mexico City"
+          }
+        ]
+      }
+    },
+    {
+      "id": 1.1,
+      "status": "pass",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "mexico city, mex"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "locality",
+            "country_a": "MEX",
+            "locality": "Mexico City"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "status": "fail",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "327 Rincon de Romos, Aguascalientes, MX"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "MEX",
+            "locality": "Aguascalientes",
+            "street": "Rincón De Romos",
+            "housenumber": "327"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2.1,
+      "status": "pass",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "327 Rincon de Romos, Aguascalientes, MEX"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "MEX",
+            "locality": "Aguascalientes",
+            "street": "Rincón De Romos",
+            "housenumber": "327"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "status": "pass",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "15 Avenue Accasias, COD"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "COD",
+            "street": "Avenue Accasias",
+            "housenumber": "15"
+          }
+        ]
+      }
+    },
+    {
+      "id": 3.1,
+      "status": "fail",
+      "user": "julian",
+      "type": "dev",
+      "in": {
+        "text": "15 Avenue Accasias, CD"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "address",
+            "country_a": "COD",
+            "street": "Avenue Accasias",
+            "housenumber": "15"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
As of this writing, Pelias stores and indexes in Elasticsearch _only_ the 3 character [ISO 3166-1](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) country code for every record.

For a select few countries, the 2 character code is not a prefix of the 3 character code (for example, Mexico is `MX`/`MEX`).

Most of Pelias can handle queries for either variant of the country code just fine.

However, the autocomplete endpoint currently does _not_ return any results if one of those few special two character codes is used.

While probably a fairly rare occurrence in actual usage, since they would generally appear at the very end of a query, it's nice to ensure these are handled properly.

This PR includes tests for 3 different autocomplete cases:

- query for a city
- two queries for addresses

Each cases is for a relevant non-prefix country code, and there are tests for both the 2 and 3 letter codes.

As of the creation of this PR, all the two letter country code query variants fail when the second character in the country code is entered, but pass otherwise once a reasonable number of characters has been entered.

Related PRs that attempt to solve this problem:
https://github.com/pelias/schema/pull/472
https://github.com/pelias/schema/pull/470
https://github.com/pelias/schema/pull/469

## Current results

![image](https://user-images.githubusercontent.com/111716/106649060-ebe90d80-6545-11eb-978b-81cf7560ca00.png)
![image](https://user-images.githubusercontent.com/111716/106649106-facfc000-6545-11eb-9755-c55ec98f6580.png)
