### PR TITLE
Add several variations of Union Square tests

### DIFF
--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -275,6 +275,102 @@
           "country_a": "USA"
         }]
       }
+    },
+    {
+      "id": 10.1,
+      "status": "fail",
+      "description": "search for Union Square, NYC with focus point",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "union square",
+        "focus.point.lon": -73.990342,
+        "focus.point.lat": 40.744243
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [ -73.99036, 40.734603 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Union Square",
+          "locality": "New York",
+          "region_a": "NY",
+          "country_a": "USA"
+        }]
+      }
+    },
+    {
+      "id": 10.2,
+      "status": "fail",
+      "description": "search for Union Square, NYC with focus point",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "union square manhattan ny",
+        "focus.point.lon": -73.990342,
+        "focus.point.lat": 40.744243
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [ -73.99036, 40.734603 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Union Square",
+          "locality": "New York",
+          "region_a": "NY",
+          "country_a": "USA"
+        }]
+      }
+    },
+    {
+      "id": 10.3,
+      "status": "fail",
+      "description": "search for Union Square, NYC with focus point",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "union square new york ny",
+        "focus.point.lon": -73.990342,
+        "focus.point.lat": 40.744243
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [ -73.99036, 40.734603 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Union Square",
+          "locality": "New York",
+          "region_a": "NY",
+          "country_a": "USA"
+        }]
+      }
+    },
+    {
+      "id": 10.4,
+      "status": "fail",
+      "description": "search for Union Square, NYC with focus point",
+      "issue": "https://github.com/pelias/pelias/issues/260",
+      "user": "julian",
+      "in": {
+        "text": "union square nyc",
+        "focus.point.lon": -73.990342,
+        "focus.point.lat": 40.744243
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "distanceThresh": 500,
+        "coordinates": [ -73.99036, 40.734603 ],
+        "properties": [{
+          "layer": "venue",
+          "name": "Union Square",
+          "locality": "New York",
+          "region_a": "NY",
+          "country_a": "USA"
+        }]
+      }
     }
   ]
 }


### PR DESCRIPTION
Union Square, NYC has long been a challenging query to get right.

The data is complex, scoring is important, and there are many other legitimate Union Squares to consider, both venues and neighbourhoods.

Connects https://github.com/pelias/pelias/issues/202
Connects https://github.com/pelias/pelias/issues/321