### PR TITLE
Update tests for improved region labels

### DIFF
--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -412,7 +412,13 @@
       "expected": {
         "priorityThresh": 1,
         "properties": [
-          { "label": "18 Glasgow Street, Kelburn, New Zealand" }
+          {
+            "housenumber": "18",
+            "street": "Glasgow Street",
+            "locality": "Kelburn",
+            "localadmin": "Wellington",
+            "country_a": "NZL"
+          }
         ]
       }
     },

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -182,7 +182,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "McDonald's, Singapore, Singapore"
+          "label": "McDonald's, Singapore"
         }]
       }
     },

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -99,7 +99,7 @@
       },
       "expected": {
         "properties": [{
-          "label": "Erbil, Iraq"
+          "label": "Erbil, AR, Iraq"
         }]
       }
     },

--- a/test_cases/labels.json
+++ b/test_cases/labels.json
@@ -426,6 +426,21 @@
           }
         ]
       }
+    },
+    {
+      "id": 27,
+      "status": "pass",
+      "user": "julian",
+      "description": [ "NZ addresses should include locality, region" ],
+      "in": {
+        "text": "18 glasgow street, kelburn, wellington"
+      },
+      "expected": {
+        "priorityThresh": 1,
+        "properties": [
+          { "label": "18 Glasgow Street, Kelburn, WG, New Zealand" }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Thanks to our work in https://github.com/pelias/labels/pull/43 and https://github.com/pelias/labels/pull/45 we have improved labels in many cases.

Fortunately, because we learned long ago to prefer checking the `label` field in dedicated label acceptance-tests, there aren't too many places that need updating!