### PR TITLE
Add leading-zero postalcode tests

### DIFF
--- a/test_cases/search_postalcodes.json
+++ b/test_cases/search_postalcodes.json
@@ -110,6 +110,47 @@
           }
         ]
       }
+    },
+    {
+      "id": "5",
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/898",
+      "user": "julian",
+      "in": {
+        "text": "03100",
+        "boundary.country": "FRA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "03100",
+            "layer": "postalcode",
+            "postalcode": "03100",
+            "country_a": "FRA"
+          }
+        ]
+      }
+    },
+    {
+      "id": "5",
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/898",
+      "user": "julian",
+      "in": {
+        "text": "04106",
+        "boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "04106",
+            "layer": "postalcode",
+            "postalcode": "04106",
+            "region_a": "ME",
+            "country_a": "USA"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds tests for a particular type of postalcode we've had trouble with: those with a leading zero.

Tests are added to the existing 'search postalcode' suite, and a new 'autocomplete postalcode' suite is also created.

We have https://github.com/pelias/schema/pull/475 in progress which we hope can fix the current known issues.

Connects https://github.com/pelias/pelias/issues/898