### PR TITLE
Add postalcode autocomplete tests

### DIFF
--- a/test_cases/autocomplete_postalcodes.json
+++ b/test_cases/autocomplete_postalcodes.json
@@ -1,0 +1,177 @@
+{
+  "name": "autocomplete_postalcodes",
+  "notes": "For testing postalcode queries",
+  "priorityThresh": 1,
+  "endpoint": "autocomplete",
+  "tests": [
+    {
+      "id": "1",
+      "status": "fail",
+      "issue": "https://github.com/pelias/pelias/issues/692",
+      "description": "currently brings in irrelevant record first, needs better scoring",
+      "user": "diana",
+      "in": {
+        "text": "90210"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "postalcode",
+            "name": "90210",
+            "locality": "Los Angeles",
+            "region": "California"
+          }
+        ]
+      }
+    },
+    {
+      "id": "2",
+      "status": "pass",
+      "user": "diana",
+      "in": {
+        "text": "LA1 1DL"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "postalcode",
+            "name": "LA1 1DL",
+            "locality": "Lancaster",
+            "country": "United Kingdom"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3",
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/692",
+      "user": "diana",
+      "in": {
+        "text": "M2M 1C8"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "M2M 1C8",
+            "postalcode": "M2M 1C8",
+            "postalcode_gid": "whosonfirst:postalcode:521433719",
+            "accuracy": "centroid",
+            "country": "Canada",
+            "region": "Ontario",
+            "locality": "Toronto",
+            "label": "M2M 1C8, Toronto, ON, Canada"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3.1",
+      "status": "pass",
+      "issue": "https://github.com/pelias/pelias/issues/692",
+      "user": "diana",
+      "in": {
+        "text": "M2M1C8"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "M2M 1C8",
+            "postalcode": "M2M 1C8",
+            "postalcode_gid": "whosonfirst:postalcode:521433719",
+            "accuracy": "centroid",
+            "country": "Canada",
+            "region": "Ontario",
+            "locality": "Toronto",
+            "label": "M2M 1C8, Toronto, ON, Canada"
+          }
+        ]
+      }
+    },
+    {
+      "id": "4",
+      "status": "fail",
+      "issue": "https://github.com/pelias/pelias/issues/898",
+      "user": "julian",
+      "in": {
+        "text": "03100",
+        "boundary.country": "FRA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "03100",
+            "layer": "postalcode",
+            "postalcode": "03100",
+            "country_a": "FRA"
+          }
+        ]
+      }
+    },
+    {
+      "id": "4",
+      "status": "fail",
+      "issue": "https://github.com/pelias/pelias/issues/898",
+      "user": "julian",
+      "in": {
+        "text": "04106",
+        "boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "04106",
+            "layer": "postalcode",
+            "postalcode": "04106",
+            "region_a": "ME",
+            "country_a": "USA"
+          }
+        ]
+      }
+    },
+    {
+      "id": "5",
+      "status": "fail",
+      "issue": "https://github.com/pelias/pelias/issues/676",
+      "user": "julian",
+      "in": {
+        "text": "90210",
+        "layers": "postalcode",
+        "boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "90210",
+            "layer": "postalcode",
+            "postalcode": "90210",
+            "region_a": "CA",
+            "country_a": "USA"
+          }
+        ]
+      }
+    },
+    {
+      "id": "5.1",
+      "status": "fail",
+      "issue": "https://github.com/pelias/pelias/issues/676",
+      "user": "julian",
+      "in": {
+        "text": "9021",
+        "layers": "postalcode",
+        "boundary.country": "USA"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "90210",
+            "layer": "postalcode",
+            "postalcode": "90210",
+            "region_a": "CA",
+            "country_a": "USA"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds autocomplete tests specifically around postalcode behavior.

Most of them were missed and I actually meant to commit them as part of https://github.com/pelias/acceptance-tests/pull/544. 😆 

Additionally, I've added one more test for an incomplete postalcode, to measure progress against https://github.com/pelias/pelias/issues/676.

We may be able to improve results with https://github.com/pelias/api/pull/1514