### PR TITLE
Remove overspecification of locality in postalcode test

### DIFF
--- a/test_cases/autocomplete_postalcodes.json
+++ b/test_cases/autocomplete_postalcodes.json
@@ -18,7 +18,6 @@
           {
             "layer": "postalcode",
             "name": "90210",
-            "locality": "Los Angeles",
             "region": "California"
           }
         ]


### PR DESCRIPTION
We generally try to avoid overspecifying properties in acceptance tests, and this is a good example of why.

For years we have had a technically incorrect locality property in the acceptance test for the American 90210 postal code.

While some of our existing data matched with this expectation, it isn't really correct (USPS lists Beverly Hills as the correct locality for that postal code), and it's really irrelevant to the test itself: finding the 92010 postal code shouldn't depend on the locality name in any way.