### PR TITLE
Improve tests with directionals in streetnames

### DIFF
--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -2,6 +2,18 @@
   "name": "address parsing",
   "priorityThresh": 5,
   "endpoint": "search",
+  "normalizers": {
+    "name": [
+      "toUpperCase",
+      "abbreviateDirectionals",
+      "toLowerCase"
+    ],
+    "street": [
+      "toUpperCase",
+      "abbreviateDirectionals",
+      "toLowerCase"
+    ]
+  },
   "tests": [
     {
       "id": 1,

--- a/test_cases/address_parsing.json
+++ b/test_cases/address_parsing.json
@@ -234,8 +234,7 @@
             "locality": "Atlanta",
             "postalcode": "30315",
             "housenumber": "186",
-            "street": "Tuskegee Street Southeast",
-            "label": "186 Tuskegee Street Southeast, Atlanta, GA, USA"
+            "street": "Tuskegee Street Southeast"
           }
         ]
       }

--- a/test_cases/washington_dc.json
+++ b/test_cases/washington_dc.json
@@ -27,13 +27,6 @@
             "street": "P Street NW",
             "locality": "Washington",
             "region": "District of Columbia"
-          },
-          {
-            "layer": "address",
-            "housenumber": "1705",
-            "street": "P Street Northwest",
-            "locality": "Washington",
-            "region": "District of Columbia"
           }
         ]
       }
@@ -54,13 +47,6 @@
             "layer": "address",
             "housenumber": "1705",
             "street": "P Street NW",
-            "locality": "Washington",
-            "region": "District of Columbia"
-          },
-          {
-            "layer": "address",
-            "housenumber": "1705",
-            "street": "P Street Northwest",
             "locality": "Washington",
             "region": "District of Columbia"
           }

--- a/test_cases/washington_dc.json
+++ b/test_cases/washington_dc.json
@@ -3,8 +3,9 @@
   "priorityThresh": 1,
   "normalizers": {
     "street": [
-      "toLowerCase",
-      "abbreviateDirectionals"
+      "toUpperCase",
+      "abbreviateDirectionals",
+      "toLowerCase"
     ]
   },
   "tests": [


### PR DESCRIPTION
In recent work such as https://github.com/pelias/openaddresses/pull/486 and https://github.com/pelias/openstreetmap/pull/560, we've attempted to ensure that street directionals (specifically the diagonals like Southwest, Northeast, etc) are handled consistently.

The intention is that these directionals are always _abbreviated_.

Our acceptance tests have long had some inconsistencies in how they handle directionals that this exposes:
- first of all, any tests that expected both `Somestreet NW` and `Somestreet Northwest` to be present need to be updated
- Some tests did not properly use our [normalizers](https://github.com/pelias/fuzzy-tester#normalizers) or did not handle a normalizer related bug (https://github.com/pelias/fuzzy-tester/issues/201)
