### PR TITLE
August test updates

### DIFF
--- a/test_cases/autocomplete_address.json
+++ b/test_cases/autocomplete_address.json
@@ -33,7 +33,7 @@
     },
     {
       "id": 2,
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/openstreetmap/pull/549",
       "description": "popular address (White House) should be returned first",
       "user": "julian",

--- a/test_cases/autocomplete_multi_lang.json
+++ b/test_cases/autocomplete_multi_lang.json
@@ -61,7 +61,7 @@
     },
     {
       "id": "2-1",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "issue": "https://github.com/pelias/pelias/issues/767",
       "in": {
@@ -98,7 +98,7 @@
     },
     {
       "id": "4-1",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "in": {
         "lang": "zh",
@@ -117,7 +117,7 @@
     },
     {
       "id": "5-1",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "in": {
         "lang": "de",
@@ -175,7 +175,7 @@
     },
     {
       "id": "6-3",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "issue": "https://github.com/pelias/pelias/issues/699",
       "in": {

--- a/test_cases/autocomplete_postalcodes.json
+++ b/test_cases/autocomplete_postalcodes.json
@@ -89,7 +89,7 @@
     },
     {
       "id": "4",
-      "status": "pass",
+      "status": "fail",
       "issue": "https://github.com/pelias/pelias/issues/898",
       "description": "postalcode in france with leading zero",
       "user": "julian",
@@ -110,7 +110,7 @@
     },
     {
       "id": "5",
-      "status": "pass",
+      "status": "fail",
       "issue": "https://github.com/pelias/pelias/issues/898",
       "description": "postalcode in USA with leading zero",
       "user": "julian",

--- a/test_cases/autocomplete_postalcodes.json
+++ b/test_cases/autocomplete_postalcodes.json
@@ -154,7 +154,7 @@
     },
     {
       "id": "6.1",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/676",
       "description": "partial postal code autocomplete query, querying only on postalcode layer",
       "user": "julian",
@@ -177,7 +177,7 @@
     },
     {
       "id": "6.2",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/676",
       "description": "partial postal code autocomplete query",
       "user": "julian",

--- a/test_cases/autocomplete_postalcodes.json
+++ b/test_cases/autocomplete_postalcodes.json
@@ -6,9 +6,9 @@
   "tests": [
     {
       "id": "1",
-      "status": "fail",
+      "status": "pass",
       "issue": "https://github.com/pelias/pelias/issues/692",
-      "description": "currently brings in irrelevant record first, needs better scoring",
+      "description": "autocomplete for a complete postalcode",
       "user": "diana",
       "in": {
         "text": "90210"

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -752,7 +752,7 @@
     },
     {
       "id": 1600,
-      "status": "fail",
+      "status": "pass",
       "endpoint": "search",
       "description": "county should be after locality generally",
       "issue": [

--- a/test_cases/search_city_country.json
+++ b/test_cases/search_city_country.json
@@ -279,7 +279,7 @@
     },
     {
       "id": 15,
-      "status": "fail",
+      "status": "pass",
       "user": "trescube",
       "type": "dev",
       "in": {

--- a/test_cases/structured_geocoding.json
+++ b/test_cases/structured_geocoding.json
@@ -473,8 +473,8 @@
       "expected": {
         "properties": [
           {
-            "layer": "localadmin",
-            "name": "Zickrick Township",
+            "layer": "locality",
+            "name": "Zickrick",
             "country_a": "USA",
             "country": "United States",
             "localadmin": "Zickrick Township"
@@ -495,8 +495,8 @@
       "expected": {
         "properties": [
           {
-            "layer": "localadmin",
-            "name": "Zumbehl Township",
+            "layer": "locality",
+            "name": "Zumbehl",
             "country_a": "USA",
             "country": "United States",
             "localadmin": "Zumbehl Township"
@@ -518,8 +518,8 @@
       "expected": {
         "properties": [
           {
-            "layer": "localadmin",
-            "name": "Aastad Township",
+            "layer": "locality",
+            "name": "Aastad",
             "country_a": "USA",
             "country": "United States",
             "region_a": "MN",


### PR DESCRIPTION
Our usual periodic round of cleanup for acceptance tests that have changed state over time.

This PR includes lots of marking improvements as passing. Some around language features, some around postal code handling, etc. Details are in the individual commits.