### PR TITLE
November test updates

### DIFF
--- a/test_cases/address_type.json
+++ b/test_cases/address_type.json
@@ -13,7 +13,7 @@
       "user": "missinglink",
       "endpoint": "search",
       "description": [
-        "Ensure address records are stored in the 'osmaddress' layer."
+        "Ensure address records are stored in the 'address' layer."
       ],
       "in": {
         "text": "102 Fleet Street",

--- a/test_cases/address_type.json
+++ b/test_cases/address_type.json
@@ -16,17 +16,17 @@
         "Ensure address records are stored in the 'address' layer."
       ],
       "in": {
-        "text": "102 Fleet Street",
+        "text": "130 Fleet Street",
         "focus.point.lat": 51.53177,
         "focus.point.lon": -0.06672
       },
       "expected": {
         "properties": [
           {
-            "gid": "openstreetmap:address:node/1401849738",
+            "gid": "openstreetmap:address:way/39275971",
             "layer": "address",
             "source": "openstreetmap",
-            "id": "node/1401849738"
+            "id": "way/39275971"
           }
         ]
       }

--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -179,7 +179,7 @@
     },
     {
       "id": 27,
-      "status": "fail",
+      "status": "pass",
       "user": "julian",
       "notes": [
         "Searching for New York City with a focus in Stamford, CT"
@@ -207,7 +207,7 @@
     },
     {
       "id": 28,
-      "status": "fail",
+      "status": "pass",
       "user": "julian",
       "notes": [
         "Searching for New York City with a focus in Stamford, CT"

--- a/test_cases/international.json
+++ b/test_cases/international.json
@@ -188,7 +188,7 @@
       "expected": {
         "properties": [
           {
-            "name": "15 Фурштатская улица",
+            "name": "Фурштатская улица 15",
             "locality": "Saint Petersburg City",
             "country_a": "RUS"
           }

--- a/test_cases/placeholder_general.json
+++ b/test_cases/placeholder_general.json
@@ -380,7 +380,7 @@
           {
             "gid": "whosonfirst:locality:101751765",
             "confidence": 0.6,
-            "name": "Luxembourg City"
+            "name": "Luxembourg"
           }
         ]
       },

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -127,7 +127,7 @@
       "id": 200,
       "status": "pass",
       "endpoint": "search",
-      "description": "the country Luxembourg should rank higher than cities of the same name",
+      "description": "the country of Belgium should rank higher than cities of the same name",
       "in": {
         "text": "Belgium"
       },

--- a/test_cases/placeholder_sorting.json
+++ b/test_cases/placeholder_sorting.json
@@ -144,14 +144,14 @@
       "id": 201,
       "status": "pass",
       "endpoint": "search",
-      "description": "the country Luxembourg should rank higher than cities and regions of the same name",
+      "description": "the city of Luxembourg should rank higher than cities and regions of the same name",
       "in": {
         "text": "Luxembourg"
       },
       "expected": {
         "properties": [
           {
-            "gid": "whosonfirst:country:85633275",
+            "gid": "whosonfirst:locality:101751765",
             "name": "Luxembourg"
           }
         ]

--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -217,7 +217,7 @@
       },
       "expected": {
         "priorityThresh": 1,
-        "distanceThresh": 500,
+        "distanceThresh": 1000,
         "coordinates": [  -112.012869, 33.434743 ],
         "properties": [{
           "layer": "venue",

--- a/test_cases/search_postalcodes.json
+++ b/test_cases/search_postalcodes.json
@@ -17,7 +17,6 @@
           {
             "layer": "postalcode",
             "name": "90210",
-            "locality": "Los Angeles",
             "region": "California"
           }
         ]

--- a/test_cases/wof_countries.json
+++ b/test_cases/wof_countries.json
@@ -132,12 +132,34 @@
       "description": "placeholder supports alpha3 and alpha2 country codes",
       "in": {
         "text": "LUX",
+        "layers": "country",
         "sources": "wof"
       },
       "expected": {
         "properties": [
           {
             "layer": "country",
+            "name": "Luxembourg",
+            "country": "Luxembourg",
+            "country_a": "LUX"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7.1,
+      "status": "pass",
+      "user": "Julian",
+      "issue": "https://github.com/pelias/pelias/issues/263",
+      "description": "placeholder supports alpha3 and alpha2 country codes, Luxembourg is returned as a locality",
+      "in": {
+        "text": "LUX",
+        "sources": "wof"
+      },
+      "expected": {
+        "properties": [
+          {
+            "layer": "locality",
             "name": "Luxembourg",
             "country": "Luxembourg",
             "country_a": "LUX"

--- a/test_cases/wof_neighbourhoods.json
+++ b/test_cases/wof_neighbourhoods.json
@@ -102,7 +102,7 @@
             "layer": "neighbourhood",
             "name": "９丁目",
             "locality": "八王子市",
-            "region": "東京都",
+            "region": "東京",
             "country": "日本",
             "country_a": "JPN"
           }


### PR DESCRIPTION
The usual round of periodic acceptance test updates. There are still a few more to do (as always), but these are the main ones.

Details are in the individual commits but here are some highlights:
- Luxembourg city was recently renamed from `Luxembourg City` to `Luxembourg` in WOF. This is a positive change and means Luxembourg city/country deduplication can kick in, preferring the city as per our usual rules
- A couple focus point tests are passing after https://github.com/pelias/whosonfirst/pull/529
- Various other name changes in WOF and improvements to address formatting from https://github.com/pelias/api/pull/1549