### PR TITLE
Brittle deduplication test cases

### DIFF
--- a/test_cases/deduplication.json
+++ b/test_cases/deduplication.json
@@ -103,6 +103,31 @@
           }
         ]
       }
+    },
+    {
+      "id": 5,
+      "status": "fail",
+      "user": "orangejulius",
+      "endpoint": "autocomplete",
+      "description": "Geonames 'New York City' record should not appear",
+      "in": {
+        "text": "New York"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "New York",
+            "layer": "locality"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "New York City"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/deduplication.json
+++ b/test_cases/deduplication.json
@@ -44,8 +44,8 @@
           "name": "Pennsylvania",
           "layer": "region"
         }, {
-          "name": "Pennsylvania Township",
-          "layer": "localadmin",
+          "name": "Pennsylvania",
+          "layer": "locality",
           "region": "Illinois"
         }]
       }

--- a/test_cases/deduplication.json
+++ b/test_cases/deduplication.json
@@ -150,6 +150,10 @@
         "properties": [
           {
             "name": "Berlin",
+            "gid": "geonames:locality:6547383"
+          },
+          {
+            "name": "Berlin",
             "layer": "region"
           },
           {

--- a/test_cases/deduplication.json
+++ b/test_cases/deduplication.json
@@ -128,6 +128,36 @@
           }
         ]
       }
+    },
+    {
+      "id": 6,
+      "status": "fail",
+      "user": "orangejulius",
+      "endpoint": "autocomplete",
+      "description": "Multiple Berlin records should not appear",
+      "in": {
+        "text": "Berlin"
+      },
+      "expected": {
+        "properties": [
+          {
+            "name": "Berlin",
+            "layer": "locality"
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
+          {
+            "name": "Berlin",
+            "layer": "region"
+          },
+          {
+            "name": "Berlin",
+            "layer": "localadmin"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This is an extension to #556 that uses GIDs and other brittle methods to expand deduplication test cases.

In the short term, it means we can do a better job of specifying exactly how we want results to appear when testing deduplication.

However, in the long term, it would likely mean lots of work to update GIDs or other test details to keep the tests up to date. For that reason we might not want to merge them.