### PR TITLE
Add an example of deduplication where order matters

### DIFF
--- a/test_cases/deduplication.json
+++ b/test_cases/deduplication.json
@@ -161,6 +161,26 @@
           }
         ]
       }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "user": "orangejulius",
+      "endpoint": "autocomplete",
+      "description": "City record should appear near the top, even if the preferred record started lower down",
+      "in": {
+        "text": "Anthering, Austria"
+      },
+      "expected": {
+        "priorityThresh": 2,
+        "properties": [
+          {
+            "name": "Anthering",
+            "country_a": "AUT",
+            "layer": "locality"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This test case came out of evaluating https://github.com/pelias/api/pull/1607. It passes with the current API master branch, fails with https://github.com/pelias/api/pull/1607, but passes with https://github.com/pelias/api/pull/1612