### PR TITLE
March updates

### DIFF
--- a/test_cases/autocomplete_focus.json
+++ b/test_cases/autocomplete_focus.json
@@ -76,7 +76,7 @@
         "priorityThresh": 1,
         "properties": [
           {
-            "label": "Hard Rock Cafe Berlin, Berlin, Germany"
+            "label": "Hard Rock Cafe, Berlin, Germany"
           }
         ]
       }

--- a/test_cases/autocomplete_multi_lang.json
+++ b/test_cases/autocomplete_multi_lang.json
@@ -25,7 +25,7 @@
     },
     {
       "id": "1-2",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "in": {
         "lang": "nl",
@@ -43,7 +43,7 @@
     },
     {
       "id": "1-3",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "in": {
         "lang": "nl",
@@ -80,7 +80,7 @@
     },
     {
       "id": "3-1",
-      "status": "fail",
+      "status": "pass",
       "user": "Joxit",
       "in": {
         "lang": "fr",

--- a/test_cases/autocomplete_multi_lang.json
+++ b/test_cases/autocomplete_multi_lang.json
@@ -71,7 +71,7 @@
       "expected": {
         "properties": [
           {
-            "layer": "region",
+            "layer": "locality",
             "country": "Ägypten",
             "name": "Kairo"
           }

--- a/test_cases/autocomplete_streets.json
+++ b/test_cases/autocomplete_streets.json
@@ -424,7 +424,7 @@
     },
     {
       "id": "8",
-      "status": "pass",
+      "status": "fail",
       "user": "missinglink",
       "description": [ "house number provided in 3rd position instead of 1st" ],
       "in": {

--- a/test_cases/placeholder_general.json
+++ b/test_cases/placeholder_general.json
@@ -276,7 +276,7 @@
     },
     {
       "id": 16,
-      "status": "fail",
+      "status": "pass",
       "endpoint": "search",
       "description": "ß should be treated as 'ss'. poor deduplication",
       "in": {

--- a/test_cases/search.json
+++ b/test_cases/search.json
@@ -72,7 +72,7 @@
     },
     {
       "id": 5,
-      "status": "pass",
+      "status": "fail",
       "type": "dev",
       "user": "Randy",
       "in": {
@@ -84,9 +84,12 @@
           {
             "gid": "whosonfirst:locality:85977539",
             "name": "New York"
-          },
+          }
+        ]
+      },
+      "unexpected": {
+        "properties": [
           {
-            "gid": "whosonfirst:county:102081863",
             "name": "New York County"
           }
         ]

--- a/test_cases/wof_localadmins.json
+++ b/test_cases/wof_localadmins.json
@@ -58,7 +58,7 @@
       "status": "pass",
       "user": "Stephen",
       "in": {
-        "text": "Zickrick, SD",
+        "text": "Zickrick Township, SD",
         "sources": "wof"
       },
       "expected": {


### PR DESCRIPTION
Another one of our periodic rounds of test updates.

This one includes some changes to tests around deduplication, and marks some tests that are now passing and/or failing as such.