### PR TITLE
Update 'County Durham' tests

### DIFF
--- a/test_cases/placeholder_general.json
+++ b/test_cases/placeholder_general.json
@@ -186,36 +186,42 @@
     },
     {
       "id": 11,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
-      "description": "GB counties with 'County' prefixed should be found",
+      "description": "GB counties with 'County' prefixed should be found. Does not currently rank first when it should",
       "in": {
         "text": "County Durham, GB"
       },
       "expected": {
         "properties": [
           {
-            "gid": "whosonfirst:region:1360698621",
-            "confidence": 0.3,
-            "name": "Durham"
+            "gid": "whosonfirst:county:1360699055",
+            "confidence": 1,
+            "name": "County Durham"
           }
         ]
       }
     },
     {
       "id": 12,
-      "status": "pass",
+      "status": "fail",
       "endpoint": "search",
-      "description": "GB counties without 'County' prefixed should be found",
+      "description": "GB counties without 'County' prefixed should be found. The city should also be found without dupes",
       "in": {
         "text": "Durham, GB"
       },
       "expected": {
+        "priorityThresh": 2,
         "properties": [
           {
-            "gid": "whosonfirst:region:1360698621",
-            "confidence": 0.3,
-            "name": "Durham"
+            "gid": "whosonfirst:locality:1360756237",
+            "confidence": 1,
+            "name": "City of Durham"
+          },
+          {
+            "gid": "whosonfirst:county:1360699055",
+            "confidence": 0.4,
+            "name": "County Durham"
           }
         ]
       }


### PR DESCRIPTION
These tests have drifted a bit over time, and don't really well represent the data we now have.

Unfortunately what looks like the intent of these tests is no longer achieved, so they are marked failing.

The results improve with our current deduplication work, but won't be fully correct until we update WOF and ensure https://spelunker.whosonfirst.org/id/1360756237/ (City of Durham locality) is parented by https://spelunker.whosonfirst.org/id/404448031/ (City of Durham localadmin)