### PR TITLE
Fix Statue of Liberty landmark tests

### DIFF
--- a/test_cases/landmarks.json
+++ b/test_cases/landmarks.json
@@ -26,7 +26,7 @@
             "name": "Statue of Liberty",
             "locality": "New York",
             "country_a": "USA",
-            "label": "Statue of Liberty, Manhattan, New York, NY, USA"
+            "label": "Statue of Liberty, New York, NY, USA"
           }
         ]
       }


### PR DESCRIPTION
We have quite a few Statue of Liberty tests, but this one had an incorrect label from back in the days before we handled all the special cases in NYC.