### PR TITLE
Improve PHX airport POI tests

### DIFF
--- a/test_cases/search_poi.json
+++ b/test_cases/search_poi.json
@@ -241,7 +241,7 @@
       },
       "expected": {
         "priorityThresh": 1,
-        "distanceThresh": 500,
+        "distanceThresh": 1000,
         "coordinates": [  -112.012869, 33.434743 ],
         "properties": [{
           "layer": "venue",
@@ -265,7 +265,7 @@
       },
       "expected": {
         "priorityThresh": 1,
-        "distanceThresh": 500,
+        "distanceThresh": 1000,
         "coordinates": [  -112.012869, 33.434743 ],
         "properties": [{
           "layer": "venue",


### PR DESCRIPTION
These tests have not had great pass rate until https://github.com/pelias/api/pull/1620, so we didn't know that the `distanceThresh` value for the coordinate checks weren't quite correct.

Hopefully they will be passing soon!