### PR TITLE
ordinals: update street name format

### DIFF
--- a/test_cases/confidence_score.json
+++ b/test_cases/confidence_score.json
@@ -14,9 +14,9 @@
       "expected": {
         "properties": [
           {
-            "name": "1 West 72 Street",
+            "name": "1 West 72nd Street",
             "housenumber": "1",
-            "street": "West 72 Street",
+            "street": "West 72nd Street",
             "country_a": "USA",
             "postalcode": "10023",
             "confidence": 1


### PR DESCRIPTION
openaddresses data will now always have the ordinal appended for numeric street names

links: https://github.com/pelias/openaddresses/pull/508