### PR TITLE
Alphanumeric housenumber test improvements

### DIFF
--- a/test_cases/search_alphanumeric_housenumber.json
+++ b/test_cases/search_alphanumeric_housenumber.json
@@ -196,6 +196,95 @@
           }
         ]
       }
+    },
+    {
+      "id": "6.1",
+      "status": "fail",
+      "in": {
+        "text": "kinkerstraat 175 F, amsterdam"
+      },
+      "description": "As above, we currently dont support permutations of the unit number, as in this example with a space",
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "175F",
+            "street": "Kinkerstraat",
+            "locality": "Amsterdam",
+            "country_a": "NLD"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "status": "pass",
+      "in": {
+        "text": "Vanadiumweg 11C, Amersfoort"
+      },
+      "description": "Dutch address in a building with housenumbers like 175A, 175B, 175C, etc. Without proper sorting the desired result can easily be drowned out",
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "11C",
+            "street": "Vanadiumweg",
+            "locality": "Amersfoort",
+            "country_a": "NLD"
+          }
+        ]
+      }
+    },
+    {
+      "id": "7.1",
+      "status": "pass",
+      "in": {
+        "text": "Vanadiumweg 11, Amersfoort"
+      },
+      "description": "Expect the housenumber 11 (with no unit suffix) to appear before those with a unit suffix",
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "11",
+            "street": "Vanadiumweg",
+            "locality": "Amersfoort",
+            "country_a": "NLD"
+          }
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "status": "pass",
+      "in": {
+        "text": "봉화로167번길 35-7"
+      },
+      "description": "Korean address, there are multiple units at 35-* but none at 35",
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "35-7",
+            "street": "봉화로167번길",
+            "country_a": "KOR"
+          }
+        ]
+      }
+    },
+    {
+      "id": "8.1",
+      "status": "pass",
+      "in": {
+        "text": "봉화로167번길 35"
+      },
+      "description": "As above, query is for 35 without unit suffix. Sorting is arbitrary.",
+      "expected": {
+        "priorityThresh": 10,
+        "properties": [
+          {
+            "housenumber": "35-7",
+            "street": "봉화로167번길",
+            "country_a": "KOR"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/search_alphanumeric_housenumber.json
+++ b/test_cases/search_alphanumeric_housenumber.json
@@ -6,7 +6,8 @@
       "toLowerCase"
     ],
     "housenumber": [
-      "toLowerCase"
+      "toLowerCase",
+      "stripPunctuation"
     ],
     "street": [
       "toLowerCase"

--- a/test_cases/search_alphanumeric_housenumber.json
+++ b/test_cases/search_alphanumeric_housenumber.json
@@ -90,7 +90,7 @@
       "id": 3,
       "status": "pass",
       "in": {
-        "text": "15А Комсомольская улица minsk belarus"
+        "text": "15А Камсамольская вуліца minsk belarus"
       },
       "description": "Belarusian address written the localized way. Note the Cyrillic character in the query and expected result",
       "issue": "https://github.com/pelias/pelias/issues/833",
@@ -98,7 +98,7 @@
         "properties": [
           {
             "housenumber": "15А",
-            "street": "Комсомольская улица",
+            "street": "Камсамольская вуліца",
             "region": "Minsk",
             "country_a": "BLR"
           }
@@ -109,7 +109,7 @@
       "id": "3.1",
       "status": "pass",
       "in": {
-        "text": "Комсомольская улица 15А minsk belarus"
+        "text": "Камсамольская вуліца 15А minsk belarus"
       },
       "description": "Belarusian address written the 'American' way. Note the Cyrillic character in the query and expected result",
       "issue": "https://github.com/pelias/pelias/issues/833",
@@ -117,7 +117,7 @@
         "properties": [
           {
             "housenumber": "15А",
-            "street": "Комсомольская улица",
+            "street": "Камсамольская вуліца",
             "region": "Minsk",
             "country_a": "BLR"
           }

--- a/test_cases/search_alphanumeric_housenumber.json
+++ b/test_cases/search_alphanumeric_housenumber.json
@@ -178,6 +178,24 @@
           }
         ]
       }
+    },
+    {
+      "id": 6,
+      "status": "pass",
+      "in": {
+        "text": "kinkerstraat 175F, amsterdam"
+      },
+      "description": "Dutch address in a building with housenumbers like 175A, 175B, 175C, etc. Without proper sorting the desired result can easily be drowned out",
+      "expected": {
+        "properties": [
+          {
+            "housenumber": "175F",
+            "street": "Kinkerstraat",
+            "locality": "Amsterdam",
+            "country_a": "NLD"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test_cases/search_alphanumeric_housenumber.json
+++ b/test_cases/search_alphanumeric_housenumber.json
@@ -1,5 +1,5 @@
 {
-  "name": "Alphanumeric housenumbers",
+  "name": "Search Alphanumeric housenumbers",
   "priorityThresh": 5,
   "normalizers": {
     "name": [

--- a/test_cases/search_alphanumeric_housenumber.json
+++ b/test_cases/search_alphanumeric_housenumber.json
@@ -1,6 +1,6 @@
 {
   "name": "Search Alphanumeric housenumbers",
-  "priorityThresh": 5,
+  "priorityThresh": 1,
   "normalizers": {
     "name": [
       "toLowerCase"


### PR DESCRIPTION
A little cleanup to our alphanumeric housenumber tests to go with https://github.com/pelias/api/pull/1683 / https://github.com/pelias/query/pull/139.

The major changes are:
- setting `priorityThresh` to 1, as we really want the desired result to sort _first_
- fixing a test in Belarus that does not seem to line up with the streetname in OSM
- Adding a new test for the `Kinkerstraat 175F` case from https://github.com/pelias/pelias/issues/810

Minor changes:
- renaming the test suite to be prefixed by search_. This is a bit random but I think our test suites should be for a specific endpoint. Most already are, so this just adds to that trend.
- Adjust normalizers to make matching housenumbers easier, in this case between `14/a` in the results and `14a` in the test

After https://github.com/pelias/api/pull/1683 the only test we still fail on is `Via del Ponticello 38/2 Trieste italy`, where we return a place with housenumber 2, so there's very nice improvement here.