### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,12 +7,10 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-10.15
         node-version:
-          - 10.x
-          - 12.x
+          - 22.x
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'
         uses: actions/setup-node@v2-beta
         with:


### PR DESCRIPTION
CI in this repo doesn't do much, but the configuration is old so all PRs will stall on missing OSX builders.