### PR TITLE
CI: update Github Action runner Ubuntu versions to 22.04

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         node-version:
           - 22.x
     steps:


### PR DESCRIPTION
We were all over the place with these, with some going all the way back to Ubuntu 16!

Connects https://github.com/pelias/pelias/issues/951